### PR TITLE
Label azure provider image

### DIFF
--- a/Dockerfile.rhel
+++ b/Dockerfile.rhel
@@ -23,3 +23,4 @@ FROM registry.ci.openshift.org/ocp/4.10:base
 COPY --from=builder /go/src/github.com/openshift/machine-api-provider-azure/bin/machine-controller-manager /
 COPY --from=builder /go/src/github.com/openshift/machine-api-provider-azure/bin/termination-handler /
 
+LABEL io.openshift.release.operator true


### PR DESCRIPTION
We need to set io.openshift.release.operator true label for all images that go in release

