### PR TITLE
Bug 2030488: Requeue create on invalid credentials errors

### DIFF
--- a/pkg/cloud/azure/actuators/machine/actuator_test.go
+++ b/pkg/cloud/azure/actuators/machine/actuator_test.go
@@ -768,6 +768,12 @@ func TestStatusCodeBasedCreationErrors(t *testing.T) {
 			statusCode: 300,
 			requeable:  true,
 		},
+		{
+			name:       "CreateMachine",
+			event:      "Warning FailedCreate CreateError: failed to reconcile machine \"azure-actuator-testing-machine\"s: failed to create vm azure-actuator-testing-machine: failed to create or get machine: failed to create or get machine: compute.VirtualMachinesClient#CreateOrUpdate: MOCK: StatusCode=401",
+			statusCode: 401,
+			requeable:  true,
+		},
 	}
 
 	for _, tc := range cases {

--- a/pkg/cloud/azure/errors.go
+++ b/pkg/cloud/azure/errors.go
@@ -17,12 +17,23 @@ limitations under the License.
 package azure
 
 import (
+	"errors"
+
 	"github.com/Azure/go-autorest/autorest"
 )
 
 // ResourceNotFound parses the error to check if its a resource not found
 func ResourceNotFound(err error) bool {
 	if derr, ok := err.(autorest.DetailedError); ok && derr.StatusCode == 404 {
+		return true
+	}
+	return false
+}
+
+// InvalidCredentials parses the error to check if its an invalid credentials error
+func InvalidCredentials(err error) bool {
+	detailedError := autorest.DetailedError{}
+	if errors.As(err, &detailedError) && detailedError.StatusCode == 401 {
 		return true
 	}
 	return false


### PR DESCRIPTION
In several CI examples linked within the BZ, we are seeing issues with the credentials just after they are created or rotated by the CCO. It looks like once the credentials are rotated they take a few minutes to propagate.

When the Machine already exists, this is fine because the exists call returns a 401 and we requeue. 
If a new machine is added, at the moment, the invalid credentials cause it to go into a failed phase, even though, if we retried slightly later, it is likely the create would have succeeded.

This PR changes the behaviour so that 401 errors (ie the credentials you provided weren't valid) no longer fails create.
I think this is safe as we already have a number of checks in place around credentials already. If the format of the secret, or any of the values are invalid, the MachineScope fails to create.
The only reason this will cause a failure, as far as I can tell, is if we had valid credentials that have expired and need to be refreshed, in which case, this is not a terminal MAPI failure.