### PR TITLE
Bug 2085336: Ignore unknown Instance types in accelerated networking check

### DIFF
--- a/pkg/cloud/azure/actuators/machine/reconciler.go
+++ b/pkg/cloud/azure/actuators/machine/reconciler.go
@@ -506,7 +506,8 @@ func (s *Reconciler) createNetworkInterface(ctx context.Context, nicName string)
 		VnetName: s.scope.MachineConfig.Vnet,
 	}
 	if s.scope.MachineConfig.AcceleratedNetworking {
-		if !machineset.InstanceTypes[s.scope.MachineConfig.VMSize].AcceleratedNetworking {
+		// If we know the instance type isn't compatible, return an error early. Else let Azure return an error.
+		if instanceInfo, ok := machineset.InstanceTypes[s.scope.MachineConfig.VMSize]; ok && instanceInfo != nil && !instanceInfo.AcceleratedNetworking {
 			return machinecontroller.InvalidMachineConfiguration("accelerated networking not supported on instance type: %v", s.scope.MachineConfig.VMSize)
 		}
 		networkInterfaceSpec.AcceleratedNetworking = s.scope.MachineConfig.AcceleratedNetworking

--- a/pkg/cloud/azure/services/networkinterfaces/networkinterfaces.go
+++ b/pkg/cloud/azure/services/networkinterfaces/networkinterfaces.go
@@ -87,8 +87,13 @@ func (s *Service) CreateOrUpdate(ctx context.Context, spec azure.Spec) error {
 
 	// Enaled Accelerated networking
 	if s.Scope.MachineConfig.AcceleratedNetworking {
-		if !machineset.InstanceTypes[s.Scope.MachineConfig.VMSize].AcceleratedNetworking {
-			return errors.New("accelerated networking not supported on instance type " + s.Scope.MachineConfig.VMSize)
+		nicProperties, ok := machineset.InstanceTypes[s.Scope.MachineConfig.VMSize]
+		if ok {
+			if !nicProperties.AcceleratedNetworking {
+				return fmt.Errorf("accelerated networking not supported on instance type %s", s.Scope.MachineConfig.VMSize)
+			}
+		} else {
+			klog.V(4).Infof("could not determine nic properties for instance type %s", s.Scope.MachineConfig.VMSize)
 		}
 		klog.V(4).Infof("setting EnableAcceleratedNetworking to %v", s.Scope.MachineConfig.AcceleratedNetworking)
 		nicProp.EnableAcceleratedNetworking = to.BoolPtr(s.Scope.MachineConfig.AcceleratedNetworking)


### PR DESCRIPTION
If we don't have the instance type in our cache, this panics.

We need to make sure that we can still handle unknown instance types, and so, if we don't know about them, just create the instance anyway and let Azure send an error back if the instance type is incompatible.

In the future, we should use the Azure API to look this information up dynamically.

CC @kwoodson 