### PR TITLE
Bug 2093044: update getAvailabilitySetName function

### DIFF
--- a/pkg/cloud/azure/actuators/machine/reconciler.go
+++ b/pkg/cloud/azure/actuators/machine/reconciler.go
@@ -732,12 +732,19 @@ func (s *Reconciler) getOrCreateAvailabilitySet() (string, error) {
 // will be `<MachineSet Name>-as`.
 // see https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/resource-name-rules#microsoftcompute
 func (s *Reconciler) getAvailabilitySetName() string {
+	asname := ""
 	if strings.HasPrefix(s.scope.Machine.Labels[MachineSetLabelName], s.scope.Machine.Labels[machinev1.MachineClusterIDLabel]) {
-		return fmt.Sprintf("%s-as",
-			s.scope.Machine.Labels[MachineSetLabelName])
+		asname = s.scope.Machine.Labels[MachineSetLabelName]
 	} else {
-		return fmt.Sprintf("%s_%s-as",
+		asname = fmt.Sprintf("%s_%s",
 			s.scope.Machine.Labels[machinev1.MachineClusterIDLabel],
 			s.scope.Machine.Labels[MachineSetLabelName])
 	}
+	// due to the 80 character name limit, if the proposed name will be 77 or more
+	// characters, we truncate the name before adding `-as`
+	if len(asname) >= 77 { // 80 char minus room for adding `-as`
+		asname = asname[:77]
+	}
+	asname = fmt.Sprintf("%s-as", asname)
+	return asname
 }

--- a/pkg/cloud/azure/actuators/machine/reconciler.go
+++ b/pkg/cloud/azure/actuators/machine/reconciler.go
@@ -485,7 +485,7 @@ func (s *Reconciler) Delete(ctx context.Context) error {
 
 	// Delete the availability set with the given name if no virtual machines are attached to it.
 	if err := s.availabilitySetsSvc.Delete(ctx, &availabilitysets.Spec{
-		Name: s.getAvailibilitySetName(),
+		Name: s.getAvailabilitySetName(),
 	}); err != nil {
 		return fmt.Errorf("failed to delete availability set: %w", err)
 	}
@@ -716,18 +716,28 @@ func (s *Reconciler) getOrCreateAvailabilitySet() (string, error) {
 	klog.V(4).Infof("No availability zones were found for %s, an availability set will be created", s.scope.Machine.Name)
 
 	if err := s.availabilitySetsSvc.CreateOrUpdate(context.Background(), &availabilitysets.Spec{
-		Name: s.getAvailibilitySetName(),
+		Name: s.getAvailabilitySetName(),
 	}); err != nil {
 		return "", err
 	}
 
-	return s.getAvailibilitySetName(), nil
+	return s.getAvailabilitySetName(), nil
 }
 
-// getAvailibilitySetName use MachineSet or Machine name + cluster name to
-// generate availability set name
-func (s *Reconciler) getAvailibilitySetName() string {
-	return fmt.Sprintf("%s_%s-as",
-		s.scope.Machine.Labels[machinev1.MachineClusterIDLabel],
-		s.scope.Machine.Labels[MachineSetLabelName])
+// getAvailabilitySetName uses the MachineSet name and the cluster name to
+// generate an availability set name with the format
+// `<Cluster Name>_<MachineSet Name>-as`. Due to an 80 character restriction
+// on availability set names, if the MachineSet name starts with the cluster
+// name, then it will not be added a second time and the availability set name
+// will be `<MachineSet Name>-as`.
+// see https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/resource-name-rules#microsoftcompute
+func (s *Reconciler) getAvailabilitySetName() string {
+	if strings.HasPrefix(s.scope.Machine.Labels[MachineSetLabelName], s.scope.Machine.Labels[machinev1.MachineClusterIDLabel]) {
+		return fmt.Sprintf("%s-as",
+			s.scope.Machine.Labels[MachineSetLabelName])
+	} else {
+		return fmt.Sprintf("%s_%s-as",
+			s.scope.Machine.Labels[machinev1.MachineClusterIDLabel],
+			s.scope.Machine.Labels[MachineSetLabelName])
+	}
 }

--- a/pkg/cloud/azure/actuators/machine/reconciler_test.go
+++ b/pkg/cloud/azure/actuators/machine/reconciler_test.go
@@ -432,6 +432,21 @@ func TestCreateAvailabilitySet(t *testing.T) {
 				return availabilitySetsSvc
 			},
 		},
+		{
+			name:           "Availability set does not contain double cluster name when it is present in MachineSet name",
+			labels:         map[string]string{MachineSetLabelName: "clustername-msname", machinev1.MachineClusterIDLabel: "clustername"},
+			expectedASName: "clustername-msname-as",
+			availabilityZonesSvc: func() *mock_azure.MockService {
+				availabilityZonesSvc := mock_azure.NewMockService(mockCtrl)
+				availabilityZonesSvc.EXPECT().Get(gomock.Any(), gomock.Any()).Return([]string{}, nil).Times(1)
+				return availabilityZonesSvc
+			},
+			availabilitySetsSvc: func() *mock_azure.MockService {
+				availabilitySetsSvc := mock_azure.NewMockService(mockCtrl)
+				availabilitySetsSvc.EXPECT().CreateOrUpdate(gomock.Any(), gomock.Any()).Return(nil).Times(1)
+				return availabilitySetsSvc
+			},
+		},
 	}
 
 	for _, tc := range testCases {

--- a/pkg/cloud/azure/actuators/machine/reconciler_test.go
+++ b/pkg/cloud/azure/actuators/machine/reconciler_test.go
@@ -447,6 +447,24 @@ func TestCreateAvailabilitySet(t *testing.T) {
 				return availabilitySetsSvc
 			},
 		},
+		{
+			name: "Availability set name is truncated properly when over 80 characters",
+			labels: map[string]string{
+				MachineSetLabelName:             "clustername-msname-1234567890abcdefghijklmnopqrstuvwxyz-1234567890abcdefghijklm",
+				machinev1.MachineClusterIDLabel: "clustername",
+			},
+			expectedASName: "clustername-msname-1234567890abcdefghijklmnopqrstuvwxyz-1234567890abcdefghijk-as",
+			availabilityZonesSvc: func() *mock_azure.MockService {
+				availabilityZonesSvc := mock_azure.NewMockService(mockCtrl)
+				availabilityZonesSvc.EXPECT().Get(gomock.Any(), gomock.Any()).Return([]string{}, nil).Times(1)
+				return availabilityZonesSvc
+			},
+			availabilitySetsSvc: func() *mock_azure.MockService {
+				availabilitySetsSvc := mock_azure.NewMockService(mockCtrl)
+				availabilitySetsSvc.EXPECT().CreateOrUpdate(gomock.Any(), gomock.Any()).Return(nil).Times(1)
+				return availabilitySetsSvc
+			},
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
this change introduces logic to detect if the cluster name is already
present in the machineset name when generating the availability set
name. due to the fact that Azure has an 80 character limit on
availability set names[0], when the clsuter name is present in the
machineset name it is not added a second time. a test is also added for
this new logic.

[0]
https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/resource-name-rules#microsoftcompute