### PR TITLE
Bug 2085390: make Azure instance types case-insensitive

### DIFF
--- a/pkg/cloud/azure/actuators/machineset/controller.go
+++ b/pkg/cloud/azure/actuators/machineset/controller.go
@@ -138,8 +138,8 @@ func (r *Reconciler) reconcile(machineSet *machinev1.MachineSet) (ctrl.Result, e
 	}
 	instanceType, ok := InstanceTypes[strings.ToLower(providerConfig.VMSize)]
 	if !ok {
-		klog.Error("Unable to set scale from zero annotations: unknown instance type: %s", providerConfig.VMSize)
-		klog.Error("Autoscaling from zero will not work. To fix this, manually populate machine annotations for your instance type: %v", []string{cpuKey, memoryKey, gpuKey})
+		klog.Errorf("Unable to set scale from zero annotations: unknown instance type: %s", providerConfig.VMSize)
+		klog.Errorf("Autoscaling from zero will not work. To fix this, manually populate machine annotations for your instance type: %v", []string{cpuKey, memoryKey, gpuKey})
 
 		// Returning no error to prevent further reconciliation, as user intervention is now required but emit an informational event
 		r.recorder.Eventf(machineSet, corev1.EventTypeWarning, "FailedUpdate", "Failed to set autoscaling from zero annotations, instance type unknown")

--- a/pkg/cloud/azure/actuators/machineset/controller_test.go
+++ b/pkg/cloud/azure/actuators/machineset/controller_test.go
@@ -230,6 +230,28 @@ func TestReconcile(t *testing.T) {
 			expectErr: false,
 		},
 		{
+			name:                "with a case insensitive Standard_NC24 #1",
+			vmSize:              "standard_nc24",
+			existingAnnotations: make(map[string]string),
+			expectedAnnotations: map[string]string{
+				cpuKey:    "24",
+				memoryKey: "229376",
+				gpuKey:    "4",
+			},
+			expectErr: false,
+		},
+		{
+			name:                "with a case insensitive Standard_NC24 #2",
+			vmSize:              "sTaNdArD_nC24",
+			existingAnnotations: make(map[string]string),
+			expectedAnnotations: map[string]string{
+				cpuKey:    "24",
+				memoryKey: "229376",
+				gpuKey:    "4",
+			},
+			expectErr: false,
+		},
+		{
 			name:   "with existing annotations",
 			vmSize: "Standard_NC24",
 			existingAnnotations: map[string]string{


### PR DESCRIPTION
Now we have a map of instance types that we compare provided values with. Unfortunately, type names are case-sensitive, which leads to an error. When, for instance, specifying `Standard_D8s_V4` instead of `Standard_D8s_v4` (V4 is specified instead of v4), Azure provider cannot find it in the map and fails to create an instance.

This commit converts all instance types in the map to a lower case and compares them with a string in a lower case as well.