### PR TITLE
Bug 2117439: Populate internalLoadBalancer for Control Plane Machines when not set

### DIFF
--- a/pkg/cloud/azure/decode/network.go
+++ b/pkg/cloud/azure/decode/network.go
@@ -40,6 +40,30 @@ type PublicIPAddressDNSSettings struct {
 	Fqdn *string `json:"fqdn,omitempty"`
 }
 
+type LoadBalancer struct {
+	// LoadBalancerPropertiesFormat - Properties of load balancer.
+	*LoadBalancerPropertiesFormat `json:"properties,omitempty"`
+
+	Name *string `json:"name,omitempty"`
+}
+
+// LoadBalancerPropertiesFormat properties of the load balancer.
+type LoadBalancerPropertiesFormat struct {
+	FrontendIPConfigurations *[]FrontendIPConfiguration `json:"frontendIPConfigurations,omitempty"`
+}
+
+// FrontendIPConfiguration frontend IP address of the load balancer.
+type FrontendIPConfiguration struct {
+	// FrontendIPConfigurationPropertiesFormat - Properties of the load balancer probe.
+	*FrontendIPConfigurationPropertiesFormat `json:"properties,omitempty"`
+}
+
+// FrontendIPConfigurationPropertiesFormat properties of Frontend IP Configuration of the load balancer.
+type FrontendIPConfigurationPropertiesFormat struct {
+	// PrivateIPAddress - The private IP address of the IP configuration.
+	PrivateIPAddress *string `json:"privateIPAddress,omitempty"`
+}
+
 func GetNetworkInterface(nic interface{}) (*NetworkInterface, error) {
 	decodedNic := &NetworkInterface{}
 	err := mapstructure.Decode(nic, &decodedNic)
@@ -58,4 +82,15 @@ func GetPublicIPAdress(ip interface{}) (*PublicIPAddress, error) {
 	}
 
 	return decodedIP, nil
+}
+
+func GetLoadBalancers(lbs interface{}) ([]LoadBalancer, error) {
+	decodedLBs := []LoadBalancer{}
+
+	err := mapstructure.Decode(lbs, &decodedLBs)
+	if err != nil {
+		return nil, err
+	}
+
+	return decodedLBs, nil
 }

--- a/pkg/cloud/azure/services/interfaceloadbalancers/interfaceloadbalancers.go
+++ b/pkg/cloud/azure/services/interfaceloadbalancers/interfaceloadbalancers.go
@@ -1,0 +1,67 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package interfaceloadbalancers
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2021-02-01/network"
+	"github.com/openshift/machine-api-provider-azure/pkg/cloud/azure"
+)
+
+// Spec specification for networkinterface
+type Spec struct {
+	NicName           string
+	ResourceGroupName string
+}
+
+// Get provides information about a network interface.
+func (s *Service) Get(ctx context.Context, spec azure.Spec) (interface{}, error) {
+	ilbSpec, ok := spec.(*Spec)
+	if !ok {
+		return []network.LoadBalancer{}, errors.New("invalid network interface specification")
+	}
+
+	out := []network.LoadBalancer{}
+
+	iterator, err := s.Client.ListComplete(ctx, ilbSpec.ResourceGroupName, ilbSpec.NicName)
+	if err != nil {
+		return []network.LoadBalancer{}, fmt.Errorf("could not list interface load balancers: %v", err)
+	}
+
+	for iterator.NotDone() {
+		out = append(out, iterator.Value())
+
+		if err := iterator.NextWithContext(ctx); err != nil {
+			return nil, fmt.Errorf("failed to advance page: %v", err)
+		}
+	}
+
+	return out, nil
+}
+
+// CreateOrUpdate creates or updates a network interface.
+func (s *Service) CreateOrUpdate(ctx context.Context, spec azure.Spec) error {
+	return errors.New("not implemented")
+}
+
+// Delete deletes the network interface with the provided name.
+func (s *Service) Delete(ctx context.Context, spec azure.Spec) error {
+	return errors.New("not implemented")
+}

--- a/pkg/cloud/azure/services/interfaceloadbalancers/interfaceloadbalancers_stack.go
+++ b/pkg/cloud/azure/services/interfaceloadbalancers/interfaceloadbalancers_stack.go
@@ -1,0 +1,61 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package interfaceloadbalancers
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/Azure/azure-sdk-for-go/profiles/2019-03-01/network/mgmt/network"
+	"github.com/openshift/machine-api-provider-azure/pkg/cloud/azure"
+)
+
+// Get provides information about a network interface.
+func (s *StackHubService) Get(ctx context.Context, spec azure.Spec) (interface{}, error) {
+	ilbSpec, ok := spec.(*Spec)
+	if !ok {
+		return []network.LoadBalancer{}, errors.New("invalid network interface specification")
+	}
+
+	out := []network.LoadBalancer{}
+
+	iterator, err := s.Client.ListComplete(ctx, ilbSpec.ResourceGroupName, ilbSpec.NicName)
+	if err != nil {
+		return []network.LoadBalancer{}, fmt.Errorf("could not list interface load balancers: %v", err)
+	}
+
+	for iterator.NotDone() {
+		out = append(out, iterator.Value())
+
+		if err := iterator.NextWithContext(ctx); err != nil {
+			return nil, fmt.Errorf("failed to advance page: %v", err)
+		}
+	}
+
+	return out, nil
+}
+
+// CreateOrUpdate creates or updates a network interface.
+func (s *StackHubService) CreateOrUpdate(ctx context.Context, spec azure.Spec) error {
+	return errors.New("not implemented")
+}
+
+// Delete deletes the network interface with the provided name.
+func (s *StackHubService) Delete(ctx context.Context, spec azure.Spec) error {
+	return errors.New("not implemented")
+}

--- a/pkg/cloud/azure/services/interfaceloadbalancers/service.go
+++ b/pkg/cloud/azure/services/interfaceloadbalancers/service.go
@@ -1,0 +1,50 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package interfaceloadbalancers
+
+import (
+	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2021-02-01/network"
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/openshift/machine-api-provider-azure/pkg/cloud/azure"
+	"github.com/openshift/machine-api-provider-azure/pkg/cloud/azure/actuators"
+)
+
+// Service provides operations on resource groups
+type Service struct {
+	Client network.InterfaceLoadBalancersClient
+	Scope  *actuators.MachineScope
+}
+
+// getGroupsClient creates a new groups client from subscriptionid.
+func getInterfaceLoadBalancersClient(resourceManagerEndpoint, subscriptionID string, authorizer autorest.Authorizer) network.InterfaceLoadBalancersClient {
+	nicLBClient := network.NewInterfaceLoadBalancersClientWithBaseURI(resourceManagerEndpoint, subscriptionID)
+	nicLBClient.Authorizer = authorizer
+	nicLBClient.AddToUserAgent(azure.UserAgent)
+	return nicLBClient
+}
+
+// NewService creates a new groups service.
+func NewService(scope *actuators.MachineScope) azure.Service {
+	if scope.IsStackHub() {
+		return NewStackHubService(scope)
+	}
+
+	return &Service{
+		Client: getInterfaceLoadBalancersClient(scope.ResourceManagerEndpoint, scope.SubscriptionID, scope.Authorizer),
+		Scope:  scope,
+	}
+}

--- a/pkg/cloud/azure/services/interfaceloadbalancers/service_stack.go
+++ b/pkg/cloud/azure/services/interfaceloadbalancers/service_stack.go
@@ -1,0 +1,46 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package interfaceloadbalancers
+
+import (
+	"github.com/Azure/azure-sdk-for-go/profiles/2019-03-01/network/mgmt/network"
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/openshift/machine-api-provider-azure/pkg/cloud/azure"
+	"github.com/openshift/machine-api-provider-azure/pkg/cloud/azure/actuators"
+)
+
+// StackHubService provides operations on resource groups
+type StackHubService struct {
+	Client network.InterfaceLoadBalancersClient
+	Scope  *actuators.MachineScope
+}
+
+// getGroupsClient creates a new groups client from subscriptionid.
+func getInterfaceLoadBalancersClientStackHub(resourceManagerEndpoint, subscriptionID string, authorizer autorest.Authorizer) network.InterfaceLoadBalancersClient {
+	nicLBClient := network.NewInterfaceLoadBalancersClientWithBaseURI(resourceManagerEndpoint, subscriptionID)
+	nicLBClient.Authorizer = authorizer
+	nicLBClient.AddToUserAgent(azure.UserAgent)
+	return nicLBClient
+}
+
+// NewStackHubService creates a new groups service.
+func NewStackHubService(scope *actuators.MachineScope) azure.Service {
+	return &StackHubService{
+		Client: getInterfaceLoadBalancersClientStackHub(scope.ResourceManagerEndpoint, scope.SubscriptionID, scope.Authorizer),
+		Scope:  scope,
+	}
+}


### PR DESCRIPTION
We have discovered that control plane machines must have an internal load balancer set, else they will not be able to be replaced. If the value isn't there, and we create a new Machine from the same spec, it will not join the internal load balancer and control plane components such as KCM will not be able to communicate with the API server.

As Azure only allows private or public load balancers, and you can only have one of each type, it's easy for us to look up, on a control plane machine, the internal load balancer if it isn't set. If the load balancer has a private IP front end, it has to be the internal load balancer, and it has to be the only internal load balancer.

This will only affect machines that don't have the internal load balancer set and should only happen once in the lifetime of the Machine so shouldn't add much overhead to the controllers operation.