### PR TITLE
OCPBUGS-1871: Fix machine not going failed with invalid vmsize

### DIFF
--- a/pkg/cloud/azure/actuators/machine/reconciler.go
+++ b/pkg/cloud/azure/actuators/machine/reconciler.go
@@ -562,7 +562,11 @@ func (s *Reconciler) createNetworkInterface(ctx context.Context, nicName string)
 
 		skuI, err := s.resourcesSkus.Get(ctx, skuSpec)
 		if err != nil {
-			return fmt.Errorf("failed to find sku %s", s.scope.MachineConfig.VMSize)
+			if errors.Is(err, resourceskus.ErrResourceNotFound) {
+				return machinecontroller.InvalidMachineConfiguration("failed to obtain instance type information for VMSize '%s' from Azure: %s", skuSpec.Name, err)
+			} else {
+				return fmt.Errorf("failed to obtain instance type information for VMSize '%s' from Azure: %w", skuSpec.Name, err)
+			}
 		}
 
 		sku := skuI.(resourceskus.SKU)

--- a/pkg/cloud/azure/actuators/machineset/controller.go
+++ b/pkg/cloud/azure/actuators/machineset/controller.go
@@ -169,9 +169,10 @@ func getStockKeepUnit(r *Reconciler, machineSet *machinev1.MachineSet) (resource
 	skuI, err := resourceSkusService.Get(context.Background(), skuSpec)
 	if err != nil {
 		if errors.Is(err, resourceskus.ErrResourceNotFound) {
-			return resourceskus.SKU{}, mapierrors.InvalidMachineConfiguration("machine SKU information for machine type %s does not exist: %v", providerConfig.VMSize, err)
+			return resourceskus.SKU{}, mapierrors.InvalidMachineConfiguration("failed to obtain instance type information for VMSize '%s' from Azure: %s", skuSpec.Name, err)
+		} else {
+			return resourceskus.SKU{}, fmt.Errorf("failed to obtain instance type information for VMSize '%s' from Azure: %w", skuSpec.Name, err)
 		}
-		return resourceskus.SKU{}, fmt.Errorf("failed to get SKU information for %s: %w", providerConfig.VMSize, err)
 	}
 
 	sku := skuI.(resourceskus.SKU)

--- a/pkg/cloud/azure/services/resourceskus/cache_test.go
+++ b/pkg/cloud/azure/services/resourceskus/cache_test.go
@@ -55,10 +55,15 @@ func TestCacheGet(t *testing.T) {
 			resourceType: "bar",
 			have: []compute.ResourceSku{
 				{
-					Name: to.StringPtr("other"),
+					Name:         to.StringPtr("other"),
+					ResourceType: to.StringPtr("bar"),
+				},
+				{
+					Name:         to.StringPtr("other2"),
+					ResourceType: to.StringPtr("bar"),
 				},
 			},
-			err: "resource SKU with name 'foo' and category 'bar' not found in location 'test': resource not found",
+			err: "resource SKU with name 'foo' and category 'bar' not found in location 'test': resource not found: The valid bar in the current region are: [\"other\" \"other2\"]. Find out more on the valid resources in each region at https://aka.ms/azure-regionservices",
 		},
 	}
 


### PR DESCRIPTION
This error needs to be InvalidMachineConfiguration, because machine goes failed only if it finds error of that type.