### PR TITLE
OCPBUGS-3540: Fix MachineCreation condition having wrong status

### DIFF
--- a/pkg/cloud/azure/actuators/machine/reconciler.go
+++ b/pkg/cloud/azure/actuators/machine/reconciler.go
@@ -105,7 +105,7 @@ func (s *Reconciler) Create(ctx context.Context) error {
 	if err := s.CreateMachine(ctx); err != nil {
 		s.scope.MachineStatus.Conditions = setCondition(s.scope.MachineStatus.Conditions, metav1.Condition{
 			Type:    string(machinev1.MachineCreated),
-			Status:  metav1.ConditionTrue,
+			Status:  metav1.ConditionFalse,
 			Reason:  machineCreationFailedReason,
 			Message: err.Error(),
 		})


### PR DESCRIPTION
If machine creation fails, the MachineCreated condition in ProviderStatus is set to True instead of False.