### PR TITLE
OCPBUGS-2123: Fix availability sets unwanted creation for unknown vmSizes

### DIFF
--- a/pkg/cloud/azure/actuators/machine/reconciler.go
+++ b/pkg/cloud/azure/actuators/machine/reconciler.go
@@ -690,9 +690,16 @@ func (s *Reconciler) getOrCreateAvailabilitySet() (string, error) {
 		return s.scope.MachineConfig.AvailabilitySet, nil
 	}
 
+	var vmSize string
+	/// Check if we do know the vmSize.
+	// In case of known vmSize `availabilityZonesSvc` will try to determine availabilityZones for this specific vmSize,
+	// otherwise empty string will be used, and we will try to determine availabilityZones presence for vms within a region.
+	if _, ok := machineset.InstanceTypes[s.scope.MachineConfig.VMSize]; ok {
+		vmSize = s.scope.MachineConfig.VMSize
+	}
 	// Try to find the zone for the machine location
 	availabilityZones, err := s.availabilityZonesSvc.Get(context.Background(), &availabilityzones.Spec{
-		VMSize: s.scope.MachineConfig.VMSize,
+		VMSize: vmSize,
 	})
 	if err != nil {
 		return "", err


### PR DESCRIPTION
Currently, the availability zones service can not determine zones presence in case if incorrect vmSize was passed.
This PR introduces special handling for empty vmSize argument within the availability zones service. In case vmSize is an empty string, the service will try to determine AZs presence within the region.