### PR TITLE
OCPBUGS-5546: Machine Actuator should not set metadata.name

### DIFF
--- a/pkg/cloud/azure/actuators/machine_scope.go
+++ b/pkg/cloud/azure/actuators/machine_scope.go
@@ -333,11 +333,6 @@ func updateFromSecret(coreClient controllerclient.Client, scope *MachineScope) e
 		return fmt.Errorf("Azure region %v did not contain key %v",
 			secretType.String(), AzureCredsRegionKey)
 	}
-	clusterName, ok := secret.Data[AzureResourcePrefix]
-	if !ok {
-		return fmt.Errorf("Azure resource prefix %v did not contain key %v",
-			secretType.String(), AzureResourcePrefix)
-	}
 
 	env, err := getEnvironment(scope)
 	if err != nil {
@@ -373,7 +368,6 @@ func updateFromSecret(coreClient controllerclient.Client, scope *MachineScope) e
 		scope.MachineConfig.Location = string(region)
 	}
 
-	scope.MachineConfig.ObjectMeta.Name = string(clusterName)
 	scope.Authorizer = authorizer
 	scope.SubscriptionID = string(subscriptionID)
 	scope.ResourceManagerEndpoint = env.ResourceManagerEndpoint

--- a/pkg/cloud/azure/actuators/machine_scope_test.go
+++ b/pkg/cloud/azure/actuators/machine_scope_test.go
@@ -80,7 +80,6 @@ func TestCredentialsSecretSuccess(t *testing.T) {
 			AzureCredsTenantIDKey:       []byte("dummyTenantID"),
 			AzureCredsResourceGroupKey:  []byte("dummyResourceGroup"),
 			AzureCredsRegionKey:         []byte("dummyRegion"),
-			AzureResourcePrefix:         []byte("dummyClusterName"),
 		},
 	}
 
@@ -106,10 +105,6 @@ func TestCredentialsSecretSuccess(t *testing.T) {
 
 	if scope.Location() != "dummyRegion" {
 		t.Errorf("Expected location to be dummyRegion but found %s", scope.Location())
-	}
-
-	if scope.MachineConfig.Name != "dummyClusterName" {
-		t.Errorf("Expected cluster name to be dummyClusterName but found %s", scope.MachineConfig.Name)
 	}
 
 	if scope.MachineConfig.ResourceGroup != "dummyResourceGroup" {
@@ -171,11 +166,6 @@ func TestCredentialsSecretFailures(t *testing.T) {
 	}
 
 	credentialsSecret.Data["azure_region"] = []byte("dummyValue")
-	if err := testCredentialFields(credentialsSecret); err == nil {
-		t.Errorf("Expected New credentials secrets to fail")
-	}
-
-	credentialsSecret.Data["azure_resource_prefix"] = []byte("dummyValue")
 	if err := testCredentialFields(credentialsSecret); err != nil {
 		t.Errorf("Expected New credentials secrets to succeed but found : %v", err)
 	}


### PR DESCRIPTION
This was a mistake in a previous refactor, it used to set the name of the cluster object back when MAPI had a concept of cluster objects, it was renamed to set the MachineConfig name, however, that doesn't make sense now as it is setting the cluster name on the providerSpec. We should not be mutating the providerspec on every machine we create in this way, the value of this field is not used within the project anyway