### PR TITLE
OCPBUGS-7696: Fix empty clusterName references for GenerateMachinePublicIPName

### DIFF
--- a/pkg/cloud/azure/actuators/machine/reconciler.go
+++ b/pkg/cloud/azure/actuators/machine/reconciler.go
@@ -508,7 +508,7 @@ func (s *Reconciler) Delete(ctx context.Context) error {
 	}
 
 	if s.scope.MachineConfig.PublicIP {
-		publicIPName, err := azure.GenerateMachinePublicIPName(s.scope.MachineConfig.Name, s.scope.Machine.Name)
+		publicIPName, err := azure.GenerateMachinePublicIPName(s.scope.ClusterName, s.scope.Machine.Name)
 		if err != nil {
 			// Only when the generated name is longer than allowed by the Azure portal
 			// That can happen only when
@@ -613,7 +613,7 @@ func (s *Reconciler) createNetworkInterface(ctx context.Context, nicName string)
 	}
 
 	if s.scope.MachineConfig.PublicIP {
-		publicIPName, err := azure.GenerateMachinePublicIPName(s.scope.MachineConfig.Name, s.scope.Machine.Name)
+		publicIPName, err := azure.GenerateMachinePublicIPName(s.scope.ClusterName, s.scope.Machine.Name)
 		if err != nil {
 			return machinecontroller.InvalidMachineConfiguration("unable to create Public IP: %v", err)
 		}

--- a/pkg/cloud/azure/actuators/machine_scope_test.go
+++ b/pkg/cloud/azure/actuators/machine_scope_test.go
@@ -411,17 +411,22 @@ func TestGetCloudEnvironment(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			env, armEndpoint, err := GetCloudEnvironment(tc.client)
-
+			infra, err := GetInfrastructure(tc.client)
 			if tc.expectedError {
 				if err == nil {
-					t.Fatal("getCloudEnvironment() was expected to return error")
+					t.Fatal("GetInfrastructure() was expected to return error")
 				}
+
+				// We expected an error and got one.
+				// Do not proceed as we are happy with this result.
+				return
 			} else {
 				if err != nil {
-					t.Fatalf("getCloudEnvironment() was not expected to return error: %v", err)
+					t.Fatalf("GetInfrastructure() was not expected to return error: %v", err)
 				}
 			}
+
+			env, armEndpoint := GetCloudEnvironment(infra)
 
 			if env != tc.expectedEnvironment {
 				t.Fatalf("expected environment %s, got: %s", tc.expectedEnvironment, env)


### PR DESCRIPTION
The assignment of MachineConfig.Name with clusterName was removed: https://github.com/openshift/machine-api-provider-azure/pull/47 As such the value resulted in an empty string, which was used in combination with the machineName strings to produce and invalid IP address name.
This should use a valid value for clusterName by fetching it from the infrastructure object.