### PR TITLE
OCPBUGS-10762: Machine should be Failed if Machine has a Failed state on Azure

### DIFF
--- a/pkg/cloud/azure/actuators/machine/actuator.go
+++ b/pkg/cloud/azure/actuators/machine/actuator.go
@@ -28,6 +28,7 @@ import (
 	"github.com/openshift/machine-api-provider-azure/pkg/cloud/azure"
 	"github.com/openshift/machine-api-provider-azure/pkg/cloud/azure/actuators"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/klog/v2"
 	controllerclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -221,6 +222,9 @@ func (a *Actuator) Exists(ctx context.Context, machine *machinev1.Machine) (bool
 	}
 
 	isExists, err := a.reconcilerBuilder(scope).Exists(context.Background())
+	if apierrors.IsUnexpectedObjectError(err) {
+		return isExists, nil
+	}
 	if err != nil {
 		klog.Errorf("failed to check machine %s exists: %v", machine.Name, err)
 	}

--- a/pkg/cloud/azure/actuators/machine/reconciler.go
+++ b/pkg/cloud/azure/actuators/machine/reconciler.go
@@ -44,6 +44,7 @@ import (
 	"github.com/openshift/machine-api-provider-azure/pkg/cloud/azure/services/virtualmachineextensions"
 	"github.com/openshift/machine-api-provider-azure/pkg/cloud/azure/services/virtualmachines"
 	apicorev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/klog/v2"
 	"k8s.io/utils/pointer"
@@ -448,7 +449,10 @@ func (s *Reconciler) Exists(ctx context.Context) (bool, error) {
 	case machinev1.VMStateDeleting:
 		return true, fmt.Errorf("vm for machine %s has unexpected 'Deleting' provisioning state", s.scope.Machine.GetName())
 	case machinev1.VMStateFailed:
-		return true, fmt.Errorf("vm for machine %s exists, but has unexpected 'Failed' provisioning state", s.scope.Machine.GetName())
+		klog.Infof("vm for machine %s has unexpected 'Failed' provisioning state", s.scope.Machine.GetName())
+		return false, &apierrors.UnexpectedObjectError{
+			Object: s.scope.Machine,
+		}
 	}
 
 	klog.Infof("Provisioning state is '%s' for machine %s", *vm.ProvisioningState, s.scope.Machine.GetName())

--- a/pkg/cloud/azure/actuators/machine/reconciler_test.go
+++ b/pkg/cloud/azure/actuators/machine/reconciler_test.go
@@ -85,7 +85,7 @@ func TestExists(t *testing.T) {
 				ID:                "machine-test-ID",
 				ProvisioningState: "Failed",
 			},
-			expected:    true,
+			expected:    false,
 			errExpected: true,
 		},
 		{


### PR DESCRIPTION
When creating machine and attaching Azure Ultra Disks as Data Disks in Arm cluster, machine is Provisioned, but checked in azure web console, instance is failed with error ZonalAllocationFailed.

We want VMs that unexpectedly fail on Azure to also Fail appropriate machine in OpenShift. If we encounter this case, we don't want the `reconciler.Exists()` method to return an error, otherwise it would just try to reconcile the machine forerver.
We want to get the machine in a state, where the finalizers are removed and the machine is Failed.