### PR TITLE
OCPBUGS-11223: Reduce metrics cardinality

### DIFF
--- a/pkg/cloud/azure/actuators/machine/actuator_test.go
+++ b/pkg/cloud/azure/actuators/machine/actuator_test.go
@@ -766,13 +766,13 @@ func TestStatusCodeBasedCreationErrors(t *testing.T) {
 		},
 		{
 			name:       "CreateMachine",
-			event:      "Warning FailedCreate CreateError: failed to reconcile machine \"azure-actuator-testing-machine\"s: failed to create vm azure-actuator-testing-machine: failed to create or get machine: failed to create or get machine: compute.VirtualMachinesClient#CreateOrUpdate: MOCK: StatusCode=300",
+			event:      "Warning FailedCreate CreateError: failed to reconcile machine \"azure-actuator-testing-machine\"s: failed to create vm azure-actuator-testing-machine: failed to create VM: failed to create or get machine: compute.VirtualMachinesClient#CreateOrUpdate: MOCK: StatusCode=300",
 			statusCode: 300,
 			requeable:  true,
 		},
 		{
 			name:       "CreateMachine",
-			event:      "Warning FailedCreate CreateError: failed to reconcile machine \"azure-actuator-testing-machine\"s: failed to create vm azure-actuator-testing-machine: failed to create or get machine: failed to create or get machine: compute.VirtualMachinesClient#CreateOrUpdate: MOCK: StatusCode=401",
+			event:      "Warning FailedCreate CreateError: failed to reconcile machine \"azure-actuator-testing-machine\"s: failed to create vm azure-actuator-testing-machine: failed to create VM: failed to create or get machine: compute.VirtualMachinesClient#CreateOrUpdate: MOCK: StatusCode=401",
 			statusCode: 401,
 			requeable:  true,
 		},

--- a/pkg/cloud/azure/actuators/machine/reconciler.go
+++ b/pkg/cloud/azure/actuators/machine/reconciler.go
@@ -483,7 +483,7 @@ func (s *Reconciler) Delete(ctx context.Context) error {
 		metrics.RegisterFailedInstanceDelete(&metrics.MachineLabels{
 			Name:      s.scope.Machine.Name,
 			Namespace: s.scope.Machine.Namespace,
-			Reason:    err.Error(),
+			Reason:    "failed to delete OS disk",
 		})
 		return fmt.Errorf("failed to delete OS disk: %w", err)
 	}
@@ -502,7 +502,7 @@ func (s *Reconciler) Delete(ctx context.Context) error {
 		metrics.RegisterFailedInstanceDelete(&metrics.MachineLabels{
 			Name:      s.scope.Machine.Name,
 			Namespace: s.scope.Machine.Namespace,
-			Reason:    err.Error(),
+			Reason:    "failed to delete network interface",
 		})
 		return fmt.Errorf("Unable to delete network interface: %w", err)
 	}
@@ -526,7 +526,7 @@ func (s *Reconciler) Delete(ctx context.Context) error {
 			metrics.RegisterFailedInstanceDelete(&metrics.MachineLabels{
 				Name:      s.scope.Machine.Name,
 				Namespace: s.scope.Machine.Namespace,
-				Reason:    err.Error(),
+				Reason:    "failed to delete Public IP",
 			})
 			return fmt.Errorf("unable to delete Public IP: %w", err)
 		}
@@ -565,7 +565,7 @@ func (s *Reconciler) createNetworkInterface(ctx context.Context, nicName string)
 			metrics.RegisterFailedInstanceCreate(&metrics.MachineLabels{
 				Name:      s.scope.Machine.Name,
 				Namespace: s.scope.Machine.Namespace,
-				Reason:    err.Error(),
+				Reason:    "failed to obtain instance type information",
 			})
 
 			if errors.Is(err, resourceskus.ErrResourceNotFound) {
@@ -622,7 +622,7 @@ func (s *Reconciler) createNetworkInterface(ctx context.Context, nicName string)
 			metrics.RegisterFailedInstanceCreate(&metrics.MachineLabels{
 				Name:      s.scope.Machine.Name,
 				Namespace: s.scope.Machine.Namespace,
-				Reason:    err.Error(),
+				Reason:    "failed to create public IP",
 			})
 			return fmt.Errorf("unable to create Public IP: %w", err)
 		}
@@ -634,7 +634,7 @@ func (s *Reconciler) createNetworkInterface(ctx context.Context, nicName string)
 		metrics.RegisterFailedInstanceCreate(&metrics.MachineLabels{
 			Name:      s.scope.Machine.Name,
 			Namespace: s.scope.Machine.Namespace,
-			Reason:    err.Error(),
+			Reason:    "failed to create VM network interface",
 		})
 		return fmt.Errorf("unable to create VM network interface: %w", err)
 	}
@@ -702,14 +702,14 @@ func (s *Reconciler) createVirtualMachine(ctx context.Context, nicName, asName s
 			metrics.RegisterFailedInstanceCreate(&metrics.MachineLabels{
 				Name:      s.scope.Machine.Name,
 				Namespace: s.scope.Machine.Namespace,
-				Reason:    err.Error(),
+				Reason:    "failed to create VM",
 			})
 
 			var detailedError autorest.DetailedError
 			if errors.As(err, &detailedError) && detailedError.Message == "Failure sending request" {
 				return machinecontroller.InvalidMachineConfiguration("failure sending request for machine %s: %v", s.scope.Machine.Name, err)
 			}
-			return fmt.Errorf("failed to create or get machine: %w", err)
+			return fmt.Errorf("failed to create VM: %w", err)
 		}
 	} else if err != nil {
 		return fmt.Errorf("failed to get vm: %w", err)


### PR DESCRIPTION
This PR removes the full error from the Reason field in RegisterFailedInstanceXXXX metrics, because it was causing the metric to have high/unbound cardinality. The full error is still logged, so this PR should not affect the ability to troubleshoot issues.