### PR TITLE
MIXEDARCH-257: Handle the kubernetes.io/architecture label based on the Azure VM Size

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/onsi/ginkgo/v2 v2.9.5
 	github.com/onsi/gomega v1.27.7
 	github.com/openshift/api v0.0.0-20230509100629-894b49f57a15
-	github.com/openshift/machine-api-operator v0.2.1-0.20230526095704-3938d727319b
+	github.com/openshift/machine-api-operator v0.2.1-0.20230531233206-931f6f67c1c7
 	github.com/pkg/errors v0.9.1
 	github.com/spf13/cobra v1.7.0
 	golang.org/x/crypto v0.6.0

--- a/go.sum
+++ b/go.sum
@@ -305,8 +305,8 @@ github.com/openshift/client-go v0.0.0-20230503144108-75015d2347cb h1:Nij5OnaECrk
 github.com/openshift/client-go v0.0.0-20230503144108-75015d2347cb/go.mod h1:Rhb3moCqeiTuGHAbXBOlwPubUMlOZEkrEWTRjIF3jzs=
 github.com/openshift/library-go v0.0.0-20230508110756-9b7abe2c9cbf h1:ZpFAN2qprgp7jEhGPrOAwP8mmuYC9BRYzvDefg+k4GM=
 github.com/openshift/library-go v0.0.0-20230508110756-9b7abe2c9cbf/go.mod h1:PJVatR/oS/EaFciwylyAr9hORSqQHrC+5bXf4L0wsBY=
-github.com/openshift/machine-api-operator v0.2.1-0.20230526095704-3938d727319b h1:Bui00y1DNxAPvmLEb1+sKzUCRPfl01y+DNdL223f5Ns=
-github.com/openshift/machine-api-operator v0.2.1-0.20230526095704-3938d727319b/go.mod h1:cYJjVQyNskmxEixGczlLytGF9iacFubTD/UbGvu5EEY=
+github.com/openshift/machine-api-operator v0.2.1-0.20230531233206-931f6f67c1c7 h1:6/Yok3qh3FPnjw+OsefCEPbV0KFEVkr00NaEYDpAY6M=
+github.com/openshift/machine-api-operator v0.2.1-0.20230531233206-931f6f67c1c7/go.mod h1:cYJjVQyNskmxEixGczlLytGF9iacFubTD/UbGvu5EEY=
 github.com/peterbourgon/diskv v2.0.1+incompatible h1:UBdAOUP5p4RWqPBg048CAvpKN+vxiaj6gdUUzhl4XmI=
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=
 github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8 h1:KoWmjvw+nsYOo29YJK9vDA65RGE3NrOnUtO7a+RF9HU=

--- a/pkg/cloud/azure/actuators/machineset/controller_test.go
+++ b/pkg/cloud/azure/actuators/machineset/controller_test.go
@@ -102,6 +102,10 @@ var _ = Describe("Reconciler", func() {
 						Name:  to.StringPtr(resourceskus.MemoryGB),
 						Value: to.StringPtr("16"),
 					},
+					{
+						Name:  to.StringPtr(resourceskus.CPUArchitectureType),
+						Value: to.StringPtr(resourceskus.X64),
+					},
 				},
 			},
 			{
@@ -119,6 +123,60 @@ var _ = Describe("Reconciler", func() {
 					{
 						Name:  to.StringPtr(resourceskus.GPUs),
 						Value: to.StringPtr("4"),
+					},
+					{
+						Name:  to.StringPtr(resourceskus.CPUArchitectureType),
+						Value: to.StringPtr(resourceskus.X64),
+					},
+				},
+			},
+			{
+				Name:         to.StringPtr("Standard_D4ps_v5"),
+				ResourceType: to.StringPtr("virtualMachines"),
+				Capabilities: &[]compute.ResourceSkuCapabilities{
+					{
+						Name:  to.StringPtr(resourceskus.VCPUs),
+						Value: to.StringPtr("4"),
+					},
+					{
+						Name:  to.StringPtr(resourceskus.MemoryGB),
+						Value: to.StringPtr("16"),
+					},
+					{
+						Name:  to.StringPtr(resourceskus.CPUArchitectureType),
+						Value: to.StringPtr(resourceskus.Arm64),
+					},
+				},
+			},
+			{
+				Name:         to.StringPtr("Standard_D4s_v3_wrong-arch"),
+				ResourceType: to.StringPtr("virtualMachines"),
+				Capabilities: &[]compute.ResourceSkuCapabilities{
+					{
+						Name:  to.StringPtr(resourceskus.VCPUs),
+						Value: to.StringPtr("4"),
+					},
+					{
+						Name:  to.StringPtr(resourceskus.MemoryGB),
+						Value: to.StringPtr("16"),
+					},
+					{
+						Name:  to.StringPtr(resourceskus.CPUArchitectureType),
+						Value: to.StringPtr("wrong-arch"),
+					},
+				},
+			},
+			{
+				Name:         to.StringPtr("Standard_D4s_v3_missing-arch"),
+				ResourceType: to.StringPtr("virtualMachines"),
+				Capabilities: &[]compute.ResourceSkuCapabilities{
+					{
+						Name:  to.StringPtr(resourceskus.VCPUs),
+						Value: to.StringPtr("4"),
+					},
+					{
+						Name:  to.StringPtr(resourceskus.MemoryGB),
+						Value: to.StringPtr("16"),
 					},
 				},
 			},
@@ -190,6 +248,7 @@ var _ = Describe("Reconciler", func() {
 				cpuKey:    "4",
 				memoryKey: "16384",
 				gpuKey:    "0",
+				labelsKey: "kubernetes.io/arch=amd64",
 			},
 			expectedEvents: []string{},
 		}),
@@ -200,6 +259,7 @@ var _ = Describe("Reconciler", func() {
 				cpuKey:    "24",
 				memoryKey: "229376",
 				gpuKey:    "4",
+				labelsKey: "kubernetes.io/arch=amd64",
 			},
 			expectedEvents: []string{},
 		}),
@@ -215,6 +275,7 @@ var _ = Describe("Reconciler", func() {
 				cpuKey:     "24",
 				memoryKey:  "229376",
 				gpuKey:     "4",
+				labelsKey:  "kubernetes.io/arch=amd64",
 			},
 			expectedEvents: []string{},
 		}),
@@ -229,6 +290,39 @@ var _ = Describe("Reconciler", func() {
 				"annother": "existingAnnotation",
 			},
 			expectedEvents: []string{"FailedUpdate"},
+		}),
+		Entry("with a Standard_D4ps_v5 (aarch64)", reconcileTestCase{
+			vmSize:              "Standard_D4ps_v5",
+			existingAnnotations: make(map[string]string),
+			expectedAnnotations: map[string]string{
+				cpuKey:    "4",
+				memoryKey: "16384",
+				gpuKey:    "0",
+				labelsKey: "kubernetes.io/arch=arm64",
+			},
+			expectedEvents: []string{},
+		}),
+		Entry("with a vmSize missing the architecture capability", reconcileTestCase{
+			vmSize:              "Standard_D4s_v3_missing-arch",
+			existingAnnotations: make(map[string]string),
+			expectedAnnotations: map[string]string{
+				cpuKey:    "4",
+				memoryKey: "16384",
+				gpuKey:    "0",
+				labelsKey: "kubernetes.io/arch=amd64",
+			},
+			expectedEvents: []string{},
+		}),
+		Entry("with a vmSize missing an unknown architecture", reconcileTestCase{
+			vmSize:              "Standard_D4s_v3_wrong-arch",
+			existingAnnotations: make(map[string]string),
+			expectedAnnotations: map[string]string{
+				cpuKey:    "4",
+				memoryKey: "16384",
+				gpuKey:    "0",
+				labelsKey: "kubernetes.io/arch=amd64",
+			},
+			expectedEvents: []string{},
 		}),
 	)
 })

--- a/pkg/cloud/azure/services/resourceskus/sku.go
+++ b/pkg/cloud/azure/services/resourceskus/sku.go
@@ -70,6 +70,12 @@ const (
 	MaximumPlatformFaultDomainCount = "MaximumPlatformFaultDomainCount"
 	// UltraSSDAvailable identifies the capability for the support of UltraSSD data disks.
 	UltraSSDAvailable = "UltraSSDAvailable"
+	// CPUArchitectureType identifies the capability for the CPU architecture.
+	CPUArchitectureType = "CpuArchitecture"
+	// X64 and Arm64 are the possible values for CPUArchitectureType, in the Azure APIs. We will adapt them in the controller
+	// to the ones kubernetes expect.
+	X64   = "x64"
+	Arm64 = "Arm64"
 )
 
 // HasCapability return true for a capability which can be either

--- a/vendor/github.com/openshift/machine-api-operator/pkg/util/util.go
+++ b/vendor/github.com/openshift/machine-api-operator/pkg/util/util.go
@@ -16,6 +16,11 @@ limitations under the License.
 
 package util
 
+import (
+	"fmt"
+	"strings"
+)
+
 // Filter filters a list for a string.
 func Filter(list []string, strToFilter string) (newList []string) {
 	for _, item := range list {
@@ -34,4 +39,26 @@ func Contains(list []string, strToSearch string) bool {
 		}
 	}
 	return false
+}
+
+// MergeCommaSeparatedKeyValuePairs merges multiple comma separated lists of key=value pairs into a single, comma-separated, list
+// of key=value pairs. If a key is present in multiple lists, the value from the last list is used.
+func MergeCommaSeparatedKeyValuePairs(lists ...string) string {
+	merged := make(map[string]string)
+	for _, list := range lists {
+		for _, kv := range strings.Split(list, ",") {
+			kv := strings.Split(kv, "=")
+			if len(kv) != 2 {
+				// ignore invalid key=value pairs
+				continue
+			}
+			merged[kv[0]] = kv[1]
+		}
+	}
+	// convert the map back to a comma separated list
+	var result []string
+	for k, v := range merged {
+		result = append(result, fmt.Sprintf("%s=%s", k, v))
+	}
+	return strings.Join(result, ",")
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -335,7 +335,7 @@ github.com/openshift/client-go/machine/listers/machine/v1beta1
 ## explicit; go 1.20
 github.com/openshift/library-go/pkg/config/clusterstatus
 github.com/openshift/library-go/pkg/config/leaderelection
-# github.com/openshift/machine-api-operator v0.2.1-0.20230526095704-3938d727319b
+# github.com/openshift/machine-api-operator v0.2.1-0.20230531233206-931f6f67c1c7
 ## explicit; go 1.19
 github.com/openshift/machine-api-operator/pkg/controller/machine
 github.com/openshift/machine-api-operator/pkg/metrics


### PR DESCRIPTION
This PR adds the `kubernetes.io/architecture` to the MachineSet labels `machine.openshift.io/labels` annotation so that the kubernetes-autoscaler can address the autoscale from 0 cases when a workload declares a `requiredAffinity` against a (set of) specific architecture(s).

This work is currently tested on a [custom backport](https://github.com/aleskandro/kubernetes-autoscaler/compare/openshift:kubernetes-autoscaler:master...master) of kubernetes/autoscaler#5697 and kubernetes/autoscaler#5382 and expects them to enable the architecture-aware autoscale from 0 working fine. 
Adding this feature now is harmless. After the rebase of the downstream kubernetes-autoscaler lands, it will start handling the autoscale from 0 for AWS multi-arch OCP clusters.

cc @Prashanth684 @elmiko @JoelSpeed 

/hold