### PR TITLE
Set upstream labels and fix capability for the arch-aware scale from 0 in Azure

### DIFF
--- a/pkg/cloud/azure/actuators/machineset/controller.go
+++ b/pkg/cloud/azure/actuators/machineset/controller.go
@@ -53,7 +53,7 @@ const (
 	cpuKey    = "machine.openshift.io/vCPU"
 	memoryKey = "machine.openshift.io/memoryMb"
 	gpuKey    = "machine.openshift.io/GPU"
-	labelsKey = "machine.openshift.io/labels"
+	labelsKey = "capacity.cluster-autoscaler.kubernetes.io/labels"
 )
 
 // Reconciler reconciles machineSets.

--- a/pkg/cloud/azure/services/resourceskus/sku.go
+++ b/pkg/cloud/azure/services/resourceskus/sku.go
@@ -71,7 +71,7 @@ const (
 	// UltraSSDAvailable identifies the capability for the support of UltraSSD data disks.
 	UltraSSDAvailable = "UltraSSDAvailable"
 	// CPUArchitectureType identifies the capability for the CPU architecture.
-	CPUArchitectureType = "CpuArchitecture"
+	CPUArchitectureType = "CpuArchitectureType"
 	// X64 and Arm64 are the possible values for CPUArchitectureType, in the Azure APIs. We will adapt them in the controller
 	// to the ones kubernetes expect.
 	X64   = "x64"


### PR DESCRIPTION
As discussed last week, this PR resets the annotation for the arch-aware scale from 0 to the upstream labels capacity annotation so that we don't need to support both cases while transitioning to using the upstream annotations only.

This also fixes the hard-coded string with the capability name to get from the Azure APIs to catch the architecture of the workers.

/cc @elmiko 