### PR TITLE
OCPBUGS-14012: Allow created NICs to inherit tags

### DIFF
--- a/pkg/cloud/azure/actuators/machine/reconciler.go
+++ b/pkg/cloud/azure/actuators/machine/reconciler.go
@@ -196,6 +196,7 @@ func (s *Reconciler) Update(ctx context.Context) error {
 			networkIface, err := s.networkInterfacesSvc.Get(ctx, &networkinterfaces.Spec{
 				Name:     ifaceName,
 				VnetName: s.scope.MachineConfig.Vnet,
+				Tags:     s.scope.Tags,
 			})
 			if err != nil {
 				klog.Errorf("Unable to get %q network interface: %v", ifaceName, err)
@@ -499,6 +500,7 @@ func (s *Reconciler) Delete(ctx context.Context) error {
 	networkInterfaceSpec := &networkinterfaces.Spec{
 		Name:     azure.GenerateNetworkInterfaceName(s.scope.Machine.Name),
 		VnetName: s.scope.MachineConfig.Vnet,
+		Tags:     s.scope.Tags,
 	}
 
 	err = s.networkInterfacesSvc.Delete(ctx, networkInterfaceSpec)
@@ -557,6 +559,7 @@ func (s *Reconciler) createNetworkInterface(ctx context.Context, nicName string)
 	networkInterfaceSpec := &networkinterfaces.Spec{
 		Name:     nicName,
 		VnetName: s.scope.MachineConfig.Vnet,
+		Tags:     s.scope.Tags,
 	}
 	if s.scope.MachineConfig.AcceleratedNetworking {
 		skuSpec := resourceskus.Spec{

--- a/pkg/cloud/azure/services/networkinterfaces/networkinterfaces.go
+++ b/pkg/cloud/azure/services/networkinterfaces/networkinterfaces.go
@@ -49,6 +49,7 @@ type Spec struct {
 	SecurityGroupName             string
 	ApplicationSecurityGroupNames []string
 	AcceleratedNetworking         bool
+	Tags                          map[string]*string
 }
 
 // Get provides information about a network interface.

--- a/pkg/cloud/azure/services/virtualmachines/virtualmachines.go
+++ b/pkg/cloud/azure/services/virtualmachines/virtualmachines.go
@@ -112,7 +112,7 @@ func (s *Service) CreateOrUpdate(ctx context.Context, spec azure.Spec) error {
 	}
 
 	klog.V(2).Infof("getting nic %s", vmSpec.NICName)
-	nicInterface, err := networkinterfaces.NewService(s.Scope).Get(ctx, &networkinterfaces.Spec{Name: vmSpec.NICName})
+	nicInterface, err := networkinterfaces.NewService(s.Scope).Get(ctx, &networkinterfaces.Spec{Name: vmSpec.NICName, Tags: vmSpec.Tags})
 	if err != nil {
 		return err
 	}

--- a/pkg/cloud/azure/services/virtualmachines/virtualmachines_stack.go
+++ b/pkg/cloud/azure/services/virtualmachines/virtualmachines_stack.go
@@ -56,7 +56,7 @@ func (s *StackHubService) CreateOrUpdate(ctx context.Context, spec azure.Spec) e
 	}
 
 	klog.V(2).Infof("getting nic %s", vmSpec.NICName)
-	nicInterface, err := networkinterfaces.NewService(s.Scope).Get(ctx, &networkinterfaces.Spec{Name: vmSpec.NICName})
+	nicInterface, err := networkinterfaces.NewService(s.Scope).Get(ctx, &networkinterfaces.Spec{Name: vmSpec.NICName, Tags: vmSpec.Tags})
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This PR enables newly created NICs to inherit tags from a machine.