### PR TITLE
OCPBUGS-20268: update bad url endpoint termination handler test

### DIFF
--- a/pkg/termination/termination_test.go
+++ b/pkg/termination/termination_test.go
@@ -182,7 +182,9 @@ var _ = Describe("Handler Suite", func() {
 				Consistently(nodeMarkedForDeletion(testNode.Name)).Should(BeFalse())
 			})
 		})
+	})
 
+	Context("when the termination endpoint is invalid", func() {
 		Context("and the poll URL cannot be reached", func() {
 			BeforeEach(func() {
 				h.pollURL = &url.URL{Opaque: "abc#1://localhost"}

--- a/pkg/termination/termination_test.go
+++ b/pkg/termination/termination_test.go
@@ -175,7 +175,10 @@ var _ = Describe("Handler Suite", func() {
 
 		Context("and the instance termination notice is not fulfilled", func() {
 			BeforeEach(func() {
-				httpHandler = newMockHTTPHandler(emptyEvents)
+				httpHandler = newMockHTTPHandler(func(rw http.ResponseWriter, req *http.Request) {
+					atomic.AddInt32(&counter, 1)
+					emptyEvents(rw, req)
+				})
 			})
 
 			It("should not mark the node for deletion", func() {


### PR DESCRIPTION
This change moves the bad url test to its own `Context` block so that it does not get caught in the mock termination service counter. In some cases it is possible for the bad url test to be run first, when this happens the counter will never advance because the url is not valid. This produces a dead lock condition in the test. Migrating the test to its own block alleviates this issue.

This change also updates the "not fulfilled" test to ensure that the counter is updated when the http handler is replaced.