### PR TITLE
[release-4.12] OCPBUGS-22247,OCPBUGS-19549: Fix empty clusterName references for GenerateMachinePublicIPName

### DIFF
--- a/hack/ci-test.sh
+++ b/hack/ci-test.sh
@@ -20,6 +20,13 @@ set -o pipefail
 
 REPO_ROOT=$(dirname "${BASH_SOURCE}")/..
 
+# Ensure that some home var is set and that it's not the root.
+# This is required for the kubebuilder cache.
+export HOME=${HOME:=/tmp/kubebuilder-testing}
+if [ $HOME == "/" ]; then
+  export HOME=/tmp/kubebuilder-testing
+fi
+
 cd $REPO_ROOT && \
 	source ./hack/fetch-ext-bins.sh && \
 	fetch_tools && \

--- a/hack/goimports.sh
+++ b/hack/goimports.sh
@@ -1,5 +1,12 @@
 #!/bin/sh
 
+# Ensure that some home var is set and that it's not the root.
+# This is required for the kubebuilder cache.
+mkdir -p /tmp/kubebuilder-testing
+export HOME=${HOME:=/tmp/kubebuilder-testing}
+if [ ${HOME} == "/" ]; then
+  export HOME=/tmp/kubebuilder-testing
+fi
 
 for TARGET in "${@}"; do
   find "${TARGET}" -name '*.go' ! -path '*/vendor/*' ! -path '*/.build/*' -exec goimports -w {} \+

--- a/pkg/cloud/azure/actuators/machine/reconciler.go
+++ b/pkg/cloud/azure/actuators/machine/reconciler.go
@@ -508,7 +508,7 @@ func (s *Reconciler) Delete(ctx context.Context) error {
 	}
 
 	if s.scope.MachineConfig.PublicIP {
-		publicIPName, err := azure.GenerateMachinePublicIPName(s.scope.MachineConfig.Name, s.scope.Machine.Name)
+		publicIPName, err := azure.GenerateMachinePublicIPName(s.scope.ClusterName, s.scope.Machine.Name)
 		if err != nil {
 			// Only when the generated name is longer than allowed by the Azure portal
 			// That can happen only when
@@ -602,7 +602,7 @@ func (s *Reconciler) createNetworkInterface(ctx context.Context, nicName string)
 	}
 
 	if s.scope.MachineConfig.PublicIP {
-		publicIPName, err := azure.GenerateMachinePublicIPName(s.scope.MachineConfig.Name, s.scope.Machine.Name)
+		publicIPName, err := azure.GenerateMachinePublicIPName(s.scope.ClusterName, s.scope.Machine.Name)
 		if err != nil {
 			return machinecontroller.InvalidMachineConfiguration("unable to create Public IP: %v", err)
 		}

--- a/pkg/cloud/azure/actuators/machine_scope.go
+++ b/pkg/cloud/azure/actuators/machine_scope.go
@@ -82,10 +82,12 @@ func NewMachineScope(params MachineScopeParams) (*MachineScope, error) {
 		return nil, fmt.Errorf("failed to get machine provider status: %w", err)
 	}
 
-	cloudEnv, armEndpoint, err := GetCloudEnvironment(params.CoreClient)
+	infra, err := GetInfrastructure(params.CoreClient)
 	if err != nil {
-		return nil, fmt.Errorf("failed azure environment: %w", err)
+		return nil, fmt.Errorf("failed to get cluster infrastructure: %w", err)
 	}
+
+	cloudEnv, armEndpoint := GetCloudEnvironment(infra)
 
 	machineScope := &MachineScope{
 		Context:      context.Background(),
@@ -97,6 +99,7 @@ func NewMachineScope(params MachineScopeParams) (*MachineScope, error) {
 		CoreClient:    params.CoreClient,
 		MachineConfig: machineConfig,
 		MachineStatus: machineStatus,
+		ClusterName:   infra.Status.InfrastructureName,
 		// Once set, they can not be changed. Otherwise, status change computation
 		// might be invalid and result in skipping the status update.
 		origMachine:        params.Machine.DeepCopy(),
@@ -122,6 +125,7 @@ type MachineScope struct {
 	CoreClient    controllerclient.Client
 	MachineConfig *machinev1.AzureMachineProviderSpec
 	MachineStatus *machinev1.AzureMachineProviderStatus
+	ClusterName   string
 
 	// cloudEnv azure environment: AzurePublic, AzureStackCloud, etc.
 	cloudEnv string
@@ -247,17 +251,21 @@ func (m *MachineScope) IsStackHub() bool {
 	return strings.EqualFold(m.cloudEnv, string(configv1.AzureStackCloud))
 }
 
-func GetCloudEnvironment(client controllerclient.Client) (string, string, error) {
+func GetInfrastructure(client controllerclient.Client) (*configv1.Infrastructure, error) {
 	infra := &configv1.Infrastructure{}
 	infraName := controllerclient.ObjectKey{Name: globalInfrastuctureName}
 
 	if err := client.Get(context.Background(), infraName, infra); err != nil {
-		return "", "", err
+		return nil, fmt.Errorf("failed to get infrastructure: %w", err)
 	}
 
+	return infra, nil
+}
+
+func GetCloudEnvironment(infra *configv1.Infrastructure) (string, string) {
 	// When cloud environment is missing default to Azure Public Cloud
 	if infra.Status.PlatformStatus == nil || infra.Status.PlatformStatus.Azure == nil || infra.Status.PlatformStatus.Azure.CloudName == "" {
-		return string(configv1.AzurePublicCloud), "", nil
+		return string(configv1.AzurePublicCloud), ""
 	}
 
 	armEndpoint := ""
@@ -265,7 +273,7 @@ func GetCloudEnvironment(client controllerclient.Client) (string, string, error)
 		armEndpoint = infra.Status.PlatformStatus.Azure.ARMEndpoint
 	}
 
-	return string(infra.Status.PlatformStatus.Azure.CloudName), armEndpoint, nil
+	return string(infra.Status.PlatformStatus.Azure.CloudName), armEndpoint
 }
 
 // MachineConfigFromProviderSpec tries to decode the JSON-encoded spec, falling back on getting a MachineClass if the value is absent.

--- a/pkg/cloud/azure/actuators/machine_scope_test.go
+++ b/pkg/cloud/azure/actuators/machine_scope_test.go
@@ -411,17 +411,22 @@ func TestGetCloudEnvironment(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			env, armEndpoint, err := GetCloudEnvironment(tc.client)
-
+			infra, err := GetInfrastructure(tc.client)
 			if tc.expectedError {
 				if err == nil {
-					t.Fatal("getCloudEnvironment() was expected to return error")
+					t.Fatal("GetInfrastructure() was expected to return error")
 				}
+
+				// We expected an error and got one.
+				// Do not proceed as we are happy with this result.
+				return
 			} else {
 				if err != nil {
-					t.Fatalf("getCloudEnvironment() was not expected to return error: %v", err)
+					t.Fatalf("GetInfrastructure() was not expected to return error: %v", err)
 				}
 			}
+
+			env, armEndpoint := GetCloudEnvironment(infra)
 
 			if env != tc.expectedEnvironment {
 				t.Fatalf("expected environment %s, got: %s", tc.expectedEnvironment, env)


### PR DESCRIPTION
Manual cherry-pick of #52 to fix up the test script which isn't working on the 4.12 branch currently