### PR TITLE
OCPBUGS-25940: Don't create availability set when using spot instances

### DIFF
--- a/pkg/cloud/azure/actuators/machine/reconciler.go
+++ b/pkg/cloud/azure/actuators/machine/reconciler.go
@@ -791,6 +791,11 @@ func (s *Reconciler) getOrCreateAvailabilitySet() (string, error) {
 		return "", nil
 	}
 
+	if s.scope.MachineConfig.SpotVMOptions != nil {
+		klog.V(4).Infof("MachineSet %s uses spot instances, skipping availability set creation", s.scope.Machine.Name)
+		return "", nil
+	}
+
 	klog.V(4).Infof("No availability zones were found for %s, an availability set will be created", s.scope.Machine.Name)
 
 	if err := s.availabilitySetsSvc.CreateOrUpdate(context.Background(), &availabilitysets.Spec{


### PR DESCRIPTION
When we are on region without availability zones, we create availability sets for machinesets. This causes machines when using spot instances, because spot instances do not support availability sets. 

This PR disables implicit availability set creation when using spot instances.