### PR TITLE
OCPBUGS-28309: add an extra vendor exclude to snyk config

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -4,3 +4,4 @@
 exclude:
   global:
     - "vendor/**"
+    - "**/vendor/**"


### PR DESCRIPTION
this change is being added because the snyk scanning appears to pickup a vendor folder during the cachito expansion.