### PR TITLE
[release-4.13] OCPBUGS-29906: Don't create availability set when using spot instances

### DIFF
--- a/pkg/cloud/azure/actuators/machine/reconciler.go
+++ b/pkg/cloud/azure/actuators/machine/reconciler.go
@@ -788,6 +788,11 @@ func (s *Reconciler) getOrCreateAvailabilitySet() (string, error) {
 		return "", nil
 	}
 
+	if s.scope.MachineConfig.SpotVMOptions != nil {
+		klog.V(4).Infof("MachineSet %s uses spot instances, skipping availability set creation", s.scope.Machine.Name)
+		return "", nil
+	}
+
 	klog.V(4).Infof("No availability zones were found for %s, an availability set will be created", s.scope.Machine.Name)
 
 	if err := s.availabilitySetsSvc.CreateOrUpdate(context.Background(), &availabilitysets.Spec{

--- a/pkg/termination/termination_test.go
+++ b/pkg/termination/termination_test.go
@@ -124,6 +124,8 @@ var _ = Describe("Handler Suite", func() {
 		var counter int32
 
 		BeforeEach(func() {
+			counter = 0
+
 			// Ensure the polling logic is excercised in tests
 			httpHandler = newMockHTTPHandler(func(rw http.ResponseWriter, req *http.Request) {
 				if atomic.LoadInt32(&counter) == 4 {
@@ -135,15 +137,15 @@ var _ = Describe("Handler Suite", func() {
 			})
 		})
 
-		JustBeforeEach(func() {
-			// Ensure the polling logic is excercised in tests
-			for atomic.LoadInt32(&counter) < 4 {
-				continue
-			}
-		})
-
 		Context("and the handler is stopped", func() {
 			JustBeforeEach(func() {
+				// Ensure the polling logic is tested as well
+				for atomic.LoadInt32(&counter) < 4 {
+					// use 50ms since polling is set to 100ms
+					time.Sleep(50 * time.Millisecond)
+					continue
+				}
+
 				close(stop)
 			})
 
@@ -157,6 +159,15 @@ var _ = Describe("Handler Suite", func() {
 		})
 
 		Context("and the instance termination notice is fulfilled", func() {
+			JustBeforeEach(func() {
+				// Ensure the polling logic is tested as well
+				for atomic.LoadInt32(&counter) < 4 {
+					// use 50ms since polling is set to 100ms
+					time.Sleep(50 * time.Millisecond)
+					continue
+				}
+			})
+
 			It("should mark the node for deletion", func() {
 				Eventually(nodeMarkedForDeletion(testNode.Name)).Should(BeTrue())
 			})


### PR DESCRIPTION
Combination of https://github.com/openshift/machine-api-provider-azure/pull/68 and  https://github.com/openshift/machine-api-provider-azure/pull/101