### PR TITLE
OCPBUGS-38570: Fallback to PlatformFaultDomain when Zones is otherwise unset

### DIFF
--- a/pkg/cloud/azure/actuators/machine/reconciler.go
+++ b/pkg/cloud/azure/actuators/machine/reconciler.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"fmt"
 	"path"
+	"strconv"
 	"strings"
 	"time"
 
@@ -405,6 +406,8 @@ func (s *Reconciler) setMachineCloudProviderSpecifics(vm *decode.VirtualMachine)
 	}
 	if vm.Zones != nil {
 		s.scope.Machine.Labels[MachineAZLabelName] = strings.Join(*vm.Zones, ",")
+	} else if getPlatformFaultDomain(vm) != nil {
+		s.scope.Machine.Labels[MachineAZLabelName] = strconv.Itoa(int(*getPlatformFaultDomain(vm)))
 	}
 
 	if s.scope.MachineConfig.SpotVMOptions != nil {
@@ -417,6 +420,13 @@ func (s *Reconciler) setMachineCloudProviderSpecifics(vm *decode.VirtualMachine)
 		// Label on the Spec so that it is propogated to the Node
 		s.scope.Machine.Spec.Labels[machinecontroller.MachineInterruptibleInstanceLabelName] = ""
 	}
+}
+
+func getPlatformFaultDomain(vm *decode.VirtualMachine) *int32 {
+	if vm.VirtualMachineProperties == nil || vm.InstanceView == nil {
+		return nil
+	}
+	return vm.InstanceView.PlatformFaultDomain
 }
 
 // Exists checks if machine exists

--- a/pkg/cloud/azure/actuators/machine/reconciler_test.go
+++ b/pkg/cloud/azure/actuators/machine/reconciler_test.go
@@ -285,6 +285,26 @@ func TestSetMachineCloudProviderSpecificsTable(t *testing.T) {
 			expectedSpecLabels: nil,
 		},
 		{
+			name:  "with a vm with a faultdomain set",
+			scope: func(t *testing.T) *actuators.MachineScope { return newFakeScope(t, "availabilityset-worker") },
+			vm: decode.VirtualMachine{
+				VirtualMachineProperties: &decode.VirtualMachineProperties{
+					InstanceView: &decode.VirtualMachineInstanceView{
+						PlatformFaultDomain: ptr.To[int32](1),
+					},
+				},
+			},
+			expectedLabels: map[string]string{
+				actuators.MachineRoleLabel:      "availabilityset-worker",
+				machinev1.MachineClusterIDLabel: "clusterID",
+				MachineAZLabelName:              "1",
+			},
+			expectedAnnotations: map[string]string{
+				MachineInstanceStateAnnotationName: "",
+			},
+			expectedSpecLabels: nil,
+		},
+		{
 			name: "with a vm on spot",
 			scope: func(t *testing.T) *actuators.MachineScope {
 				scope := newFakeScope(t, "spot-worker")

--- a/pkg/cloud/azure/decode/virtualmachine.go
+++ b/pkg/cloud/azure/decode/virtualmachine.go
@@ -24,7 +24,8 @@ type HardwareProfile struct {
 }
 
 type VirtualMachineInstanceView struct {
-	Statuses *[]InstanceViewStatus `json:"statuses,omitempty"`
+	PlatformFaultDomain *int32                `json:"platformFaultDomain,omitempty"`
+	Statuses            *[]InstanceViewStatus `json:"statuses,omitempty"`
 }
 
 type InstanceViewStatus struct {


### PR DESCRIPTION
When the CCM populates the Zone label, if the zone is not populated in the VM properties, it falls back to the PlatformFaultDomain. This happens when using availability sets as availability sets are not compatible with availability zones.

See https://github.com/kubernetes-sigs/cloud-provider-azure/blob/b375c2a64ed15fa3ca1c170f12d608405f12b97d/pkg/provider/azure_standard.go#L583

This updates our zone fetching logic to implement the same fallback.