### PR TITLE
OCPBUGS-31515: Re-reconcile machine on NIC provisioning failure

### DIFF
--- a/pkg/cloud/azure/actuators/machine/reconciler.go
+++ b/pkg/cloud/azure/actuators/machine/reconciler.go
@@ -129,7 +129,7 @@ func (s *Reconciler) CreateMachine(ctx context.Context) error {
 	}
 
 	nicName := azure.GenerateNetworkInterfaceName(s.scope.Machine.Name)
-	if err := s.createNetworkInterface(ctx, nicName); err != nil {
+	if err := s.createOrUpdateNetworkInterface(ctx); err != nil {
 		return fmt.Errorf("failed to create nic %s for machine %s: %w", nicName, s.scope.Machine.Name, err)
 	}
 
@@ -217,6 +217,14 @@ func (s *Reconciler) Update(ctx context.Context) error {
 			if err != nil {
 				klog.Errorf("Network interfaces get returned invalid network interface, getting %T instead", networkIface)
 				continue
+			}
+
+			// If the NIC has a failed provision operation, attempt to update it. Requeue on failure.
+			if *niface.ProvisioningState == networkinterfaces.ProvisioningStateFailed {
+				klog.V(4).Infof("network interface %q in provisioning failed state, attempting to update", ifaceName)
+				if err := s.createOrUpdateNetworkInterface(ctx); err != nil {
+					return fmt.Errorf("network interface %s failed to provision", ifaceName)
+				}
 			}
 
 			// Internal dns name consists of a hostname and internal dns suffix
@@ -554,10 +562,12 @@ func (s *Reconciler) getZone(ctx context.Context) (string, error) {
 	return s.scope.MachineConfig.Zone, nil
 }
 
-func (s *Reconciler) createNetworkInterface(ctx context.Context, nicName string) error {
+// createOrUpdateNetworkInterface generates a networkinterface spec based on the Machine being reconciled and submits it for creation or updating.
+func (s *Reconciler) createOrUpdateNetworkInterface(ctx context.Context) error {
 	if s.scope.MachineConfig.Vnet == "" {
 		return machinecontroller.InvalidMachineConfiguration("MachineConfig vnet is missing on machine %s", s.scope.Machine.Name)
 	}
+	nicName := azure.GenerateNetworkInterfaceName(s.scope.Machine.Name)
 	networkInterfaceSpec := &networkinterfaces.Spec{
 		Name:     nicName,
 		VnetName: s.scope.MachineConfig.Vnet,

--- a/pkg/cloud/azure/decode/network.go
+++ b/pkg/cloud/azure/decode/network.go
@@ -9,8 +9,9 @@ type NetworkInterface struct {
 }
 
 type InterfacePropertiesFormat struct {
-	DNSSettings      *InterfaceDNSSettings       `json:"dnsSettings,omitempty"`
-	IPConfigurations *[]InterfaceIPConfiguration `json:"ipConfigurations,omitempty"`
+	DNSSettings       *InterfaceDNSSettings       `json:"dnsSettings,omitempty"`
+	IPConfigurations  *[]InterfaceIPConfiguration `json:"ipConfigurations,omitempty"`
+	ProvisioningState *string                     `json:"provisioningState,omitempty"`
 }
 
 type InterfaceDNSSettings struct {


### PR DESCRIPTION
Azure allows resources to enter a "ProvisioningFailed" state without returning an error from asynchronous operations. This can result in a cascading failure of dependent resources.

According to https://learn.microsoft.com/en-us/azure/networking/troubleshoot-failed-state#provisioning-states, to remedy this, the resource itself could be operational, but the last API action was a failure. Getting then re-submitting the resource should reset the provisioning state in such a case.

For our usage, we will re-queue a `Machine` until the NICs provision successfully, expecting subsequent reconciliations to correct the NIC's state.