### PR TITLE
CORS-3883: Allow managed identity from other resource groups

### DIFF
--- a/pkg/cloud/azure/actuators/machine/reconciler.go
+++ b/pkg/cloud/azure/actuators/machine/reconciler.go
@@ -684,8 +684,12 @@ func (s *Reconciler) createVirtualMachine(ctx context.Context, nicName, asName s
 			DiagnosticsProfile:  diagnosticsProfile,
 		}
 
-		if s.scope.MachineConfig.ManagedIdentity != "" {
-			vmSpec.ManagedIdentity = azure.GenerateManagedIdentityName(s.scope.SubscriptionID, s.scope.MachineConfig.ResourceGroup, s.scope.MachineConfig.ManagedIdentity)
+		if mi := s.scope.MachineConfig.ManagedIdentity; mi != "" {
+			if !strings.HasPrefix(mi, "/subscriptions/") {
+				vmSpec.ManagedIdentity = azure.GenerateManagedIdentityName(s.scope.SubscriptionID, s.scope.MachineConfig.ResourceGroup, s.scope.MachineConfig.ManagedIdentity)
+			} else {
+				vmSpec.ManagedIdentity = mi
+			}
 		}
 
 		if vmSpec.Tags == nil {


### PR DESCRIPTION
Prior to this commit, MAPI only supports specifying a managed identity by name, and assumes that identity exists in the same resource group as the machine. This commit relaxes that requirement to allow a fully-specified id, to allow a managed identity from any resource group.

For background context openshift/installer#9538 removes the default managed-identity creation the installer has been creating since the beginning to authenticate cloud-provider-azure. With the move to out-of-tree, we have found that identity is no longer required as cloud-provider-azure is authenticated by credentials requests. Removing this automatic & unnecessary identity creation is a win for users, because they no longer need the Service Account Admin permission, which is a powerful permission.

On the other hand, it is possible that there may be a use case for having identities attached to a machine, so openshift/installer#9538 also exposes CAPZ's API to allow fuller control of VM identities, in case users need to manage it. Users can bring their own identity to attach to the VMs.

We planned on limiting this to control-plane nodes due to the limitation in MAPI addressed by this PR, but @jinyunma [pointed out](https://github.com/openshift/installer/pull/9538#discussion_r1986896547) that control-plane nodes also depend on MAPI for the control-plane machineset operator.

So I want to float this PR to see if we can expand the set of values accepted by MAPI.

If this PR is unacceptable, we may consider other alternatives:

- currently the installer requires that any existing resource group is empty before using it for install. This is to protect against unintended deletion of resources when using `destroy cluster`. We could rework that validation to allow a managed identity to exist in that resource group AND enforce a user-assigned identity belong to the cluster resource group.
- we could also just not expose an identity API and simply remove the installer-created identity, but I think that leaves users with worse options, in the case they do need an identity

This PR would be my first choice though, as it is most beneficial to users.