### PR TITLE
OCPBUGS-54617: Update eviction policy for Spot VMs from Deallocate to Delete

### DIFF
--- a/pkg/cloud/azure/services/virtualmachines/virtualmachines.go
+++ b/pkg/cloud/azure/services/virtualmachines/virtualmachines.go
@@ -411,9 +411,7 @@ func getSpotVMOptions(spotVMOptions *machinev1.SpotVMOptions) (compute.VirtualMa
 		}
 	}
 
-	// We should use deallocate eviction policy it's - "the only supported eviction policy for Single Instance Spot VMs"
-	// https://github.com/openshift/enhancements/blob/master/enhancements/machine-api/spot-instances.md#eviction-policies
-	return compute.VirtualMachinePriorityTypesSpot, compute.VirtualMachineEvictionPolicyTypesDeallocate, billingProfile, nil
+	return compute.VirtualMachinePriorityTypesSpot, compute.VirtualMachineEvictionPolicyTypesDelete, billingProfile, nil
 }
 
 func generateImagePlan(image machinev1.Image) *compute.Plan {

--- a/pkg/cloud/azure/services/virtualmachines/virtualmachines_test.go
+++ b/pkg/cloud/azure/services/virtualmachines/virtualmachines_test.go
@@ -842,7 +842,7 @@ func TestGetSpotVMOptions(t *testing.T) {
 				MaxPrice: &maxPrice,
 			},
 			priority:       compute.VirtualMachinePriorityTypesSpot,
-			evictionPolicy: compute.VirtualMachineEvictionPolicyTypesDeallocate,
+			evictionPolicy: compute.VirtualMachineEvictionPolicyTypesDelete,
 			billingProfile: &compute.BillingProfile{
 				MaxPrice: &maxPriceFloat,
 			},
@@ -858,7 +858,7 @@ func TestGetSpotVMOptions(t *testing.T) {
 			name:           "not return an error with empty spot vm options",
 			spotVMOptions:  &machinev1.SpotVMOptions{},
 			priority:       compute.VirtualMachinePriorityTypesSpot,
-			evictionPolicy: compute.VirtualMachineEvictionPolicyTypesDeallocate,
+			evictionPolicy: compute.VirtualMachineEvictionPolicyTypesDelete,
 			billingProfile: &compute.BillingProfile{
 				MaxPrice: nil,
 			},
@@ -869,7 +869,7 @@ func TestGetSpotVMOptions(t *testing.T) {
 				MaxPrice: nil,
 			},
 			priority:       compute.VirtualMachinePriorityTypesSpot,
-			evictionPolicy: compute.VirtualMachineEvictionPolicyTypesDeallocate,
+			evictionPolicy: compute.VirtualMachineEvictionPolicyTypesDelete,
 			billingProfile: &compute.BillingProfile{
 				MaxPrice: nil,
 			},


### PR DESCRIPTION
This fixes a bug where the spot machine was stuck in provisioned if it got deallocated before it was able to schedule the interruption handler. Now the machine will be deleted by Azure and go failed as expected.

It no longer says in the docs that Deallocate policy is not supported. I think that it is supported now. I am able to select delete policy in the Azure portal.

Therefore, I think we should switch to delete policy as this is preferred for our usecase.