### PR TITLE
OCPBUGS-56380: Fix failure when attempting to modify immutable availabilitySet

### DIFF
--- a/pkg/cloud/azure/services/availabilitysets/availabilitysets.go
+++ b/pkg/cloud/azure/services/availabilitysets/availabilitysets.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"reflect"
 	"strconv"
 
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2021-11-01/compute"
@@ -23,27 +24,45 @@ func (s *Service) CreateOrUpdate(ctx context.Context, spec azure.Spec) error {
 	if !ok {
 		return errors.New("invalid availability set specification")
 	}
-	faultDomainCount, err := s.getMaximumFaultDomainCount(ctx)
-	if err != nil {
-		return fmt.Errorf("failed to get fault domain count: %w", err)
+
+	existingAvailabilitySet, err := s.Client.Get(ctx, s.Scope.MachineConfig.ResourceGroup, availabilitysetsSpec.Name)
+	if err != nil && !azure.ResourceNotFound(err) {
+		return fmt.Errorf("failed to get availability set %s: %w", availabilitysetsSpec.Name, err)
 	}
 
-	asParams := compute.AvailabilitySet{
-		Name: to.StringPtr(availabilitysetsSpec.Name),
-		Sku: &compute.Sku{
-			Name: to.StringPtr(string(compute.AvailabilitySetSkuTypesAligned)),
-		},
-		Location: to.StringPtr(s.Scope.Location()),
-		AvailabilitySetProperties: &compute.AvailabilitySetProperties{
-			PlatformFaultDomainCount:  to.Int32Ptr(int32(faultDomainCount)),
-			PlatformUpdateDomainCount: to.Int32Ptr(int32(5)),
-		},
-		Tags: s.Scope.Tags,
+	var availabilitySet compute.AvailabilitySet
+	if azure.ResourceNotFound(err) {
+		faultDomainCount, err := s.getMaximumFaultDomainCount(ctx)
+		if err != nil {
+			return fmt.Errorf("failed to get fault domain count: %w", err)
+		}
+
+		availabilitySet = compute.AvailabilitySet{
+			Name: to.StringPtr(availabilitysetsSpec.Name),
+			Sku: &compute.Sku{
+				Name: to.StringPtr(string(compute.AvailabilitySetSkuTypesAligned)),
+			},
+			Location: to.StringPtr(s.Scope.Location()),
+			AvailabilitySetProperties: &compute.AvailabilitySetProperties{
+				PlatformFaultDomainCount:  to.Int32Ptr(int32(faultDomainCount)),
+				PlatformUpdateDomainCount: to.Int32Ptr(int32(5)),
+			},
+			Tags: s.Scope.Tags,
+		}
+	} else {
+		if reflect.DeepEqual(existingAvailabilitySet.Tags, s.Scope.Tags) {
+			// Availability set already exists has desired tags.
+			// Other properties are immutable.
+			return nil
+		}
+
+		availabilitySet = existingAvailabilitySet
+		availabilitySet.Tags = s.Scope.Tags
 	}
 
-	_, err = s.Client.CreateOrUpdate(ctx, s.Scope.MachineConfig.ResourceGroup, availabilitysetsSpec.Name, asParams)
+	_, err = s.Client.CreateOrUpdate(ctx, s.Scope.MachineConfig.ResourceGroup, availabilitysetsSpec.Name, availabilitySet)
 	if err != nil {
-		return fmt.Errorf("failed to create availability set %s: %w", availabilitysetsSpec.Name, err)
+		return fmt.Errorf("failed to create or update availability set %s: %w", availabilitysetsSpec.Name, err)
 	}
 
 	return nil


### PR DESCRIPTION
Recently, a change was made to make the fault domain count dynamic instead of using a fixed number. This led to the attempt of updating the availability sets that were using the old fixed fault domain count to the new value. As availability sets are immutable, except for tags. This resulted in failure to update the availability set. 

This PR changes the logic to not update the availability set. Except for tags that can be updated.