### PR TITLE
feature: Add support for data disks on Azure Stack Hub

### DIFF
--- a/pkg/cloud/azure/services/virtualmachines/virtualmachines_stack.go
+++ b/pkg/cloud/azure/services/virtualmachines/virtualmachines_stack.go
@@ -307,6 +307,12 @@ func generateStackHubDataDisks(vmSpec *Spec) (*[]compute.DataDisk, error) {
 				dataDiskName, vmSpec.Name, machinev1.StorageAccountUltraSSDLRS, machinev1.CachingTypeNone)
 		}
 
+		if disk.ManagedDisk.DiskEncryptionSet != nil {
+			return nil, apierrors.InvalidMachineConfiguration("failed to create Data Disk: %s for vm %s. "+
+				"Disk Encryption Set is not supported for Data Disk in Azure Stack Hub.",
+				dataDiskName, vmSpec.Name)
+		}
+
 		if disk.Lun < 0 || disk.Lun > 63 {
 			return nil, apierrors.InvalidMachineConfiguration("failed to create Data Disk: %s for vm %s. "+
 				"Invalid value `lun`: %d. `lun` cannot be lower than 0 or higher than 63.",


### PR DESCRIPTION
Azure Stack Hub currently does not handle the `dataDisks` from the provider spec and silently ignores this configuration, this PR will now handle these disks allowing Machines to be launched with attached data disks on Azure Stack Hub the handling of the data disks is largely mirrored from https://github.com/openshift/machine-api-provider-azure/blob/main/pkg/cloud/azure/services/virtualmachines/virtualmachines.go, with the addition of throwing an error if the user specifies an UltraDisk or disk encryption set since these do not appear to be supported used by the model currently used by the stack hub client.