### PR TITLE
Support data disks on ASH

### DIFF
--- a/pkg/cloud/azure/services/virtualmachines/virtualmachines_stack.go
+++ b/pkg/cloud/azure/services/virtualmachines/virtualmachines_stack.go
@@ -44,6 +44,11 @@ func (s *Service) deriveVirtualMachineParametersStackHub(vmSpec *Spec, nicID str
 		}
 	}
 
+	dataDisks, err := generateDataDisks(vmSpec)
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate data disk spec: %w", err)
+	}
+
 	virtualMachine := &compute.VirtualMachine{
 		Location: ptr.To(s.Scope.MachineConfig.Location),
 		Tags:     vmSpec.Tags,
@@ -62,6 +67,7 @@ func (s *Service) deriveVirtualMachineParametersStackHub(vmSpec *Spec, nicID str
 						StorageAccountType: ptr.To(compute.StorageAccountTypes(vmSpec.OSDisk.ManagedDisk.StorageAccountType)),
 					},
 				},
+				DataDisks: dataDisks,
 			},
 			OSProfile: osProfile,
 			NetworkProfile: &compute.NetworkProfile{


### PR DESCRIPTION
Proposed replacement for
https://github.com/openshift/machine-api-provider-azure/pull/149. Thanks to
@gcampbell12 for that PR.

With https://github.com/openshift/machine-api-provider-azure/pull/155, the
Stack Hub and non-Stack Hub code paths are now mostly common in the
virtualmachine service. This PR takes advantage of that to use the common code.

This PR introduces some potentially incompatible behaviour changes when
specifying data disk features on a StackHub deployment.

Previously, specifying data disks on a StackHub deployment was silently
ignored. With this change they will be created.

Additionally, if we were previously specifying a data disk with features not
currently supported on Stack Hub, for example Disk Encryption Set, the machine
would be successfully created without any data disks. With this change the
machine will enter an error state and not be created.

As these behaviour changes only relate to configurations which were previously
invalid, we may decide that this is acceptable.
