### PR TITLE
OCPBUGS-74076: Fix: Enable boot diagnostics for Azure Stack Hub VMs

### DIFF
--- a/pkg/cloud/azure/services/virtualmachines/virtualmachines_stack.go
+++ b/pkg/cloud/azure/services/virtualmachines/virtualmachines_stack.go
@@ -80,6 +80,7 @@ func (s *Service) deriveVirtualMachineParametersStackHub(vmSpec *Spec, nicID str
 					},
 				},
 			},
+			DiagnosticsProfile: vmSpec.DiagnosticsProfile,
 		},
 	}
 


### PR DESCRIPTION
 The `deriveVirtualMachineParametersStackHub` function was missing the `DiagnosticsProfile` field assignment, causing boot diagnostics to not be applied to Azure Stack Hub VMs even when correctly specified in the Machine configuration.