### PR TITLE
OCPBUGS-74573: Add validation for AzureManaged boot diagnostics on Azure Stack Hub

### DIFF
--- a/pkg/cloud/azure/actuators/machine/reconciler.go
+++ b/pkg/cloud/azure/actuators/machine/reconciler.go
@@ -725,7 +725,7 @@ func (s *Reconciler) createVirtualMachine(ctx context.Context, nicName, asName s
 			return fmt.Errorf("failed to get zone: %w", err)
 		}
 
-		diagnosticsProfile, err := createDiagnosticsConfig(s.scope.MachineConfig)
+		diagnosticsProfile, err := createDiagnosticsConfig(s.scope, s.scope.MachineConfig)
 		if err != nil {
 			return fmt.Errorf("failed to configure diagnostics profile: %w", err)
 		}
@@ -909,7 +909,7 @@ func (s *Reconciler) getAvailabilitySetName() string {
 }
 
 // createDiagnosticsConfig sets up the diagnostics configuration for the virtual machine.
-func createDiagnosticsConfig(config *machinev1.AzureMachineProviderSpec) (*armcompute.DiagnosticsProfile, error) {
+func createDiagnosticsConfig(scope *actuators.MachineScope, config *machinev1.AzureMachineProviderSpec) (*armcompute.DiagnosticsProfile, error) {
 	boot := config.Diagnostics.Boot
 	if boot == nil {
 		return nil, nil
@@ -917,6 +917,12 @@ func createDiagnosticsConfig(config *machinev1.AzureMachineProviderSpec) (*armco
 
 	switch boot.StorageAccountType {
 	case machinev1.AzureManagedAzureDiagnosticsStorage:
+		// Validate that AzureManaged boot diagnostics is not used on Azure Stack Hub
+		if scope.IsStackHub() {
+			return nil, machinecontroller.InvalidMachineConfiguration(
+				"AzureManaged boot diagnostics is not supported on Azure Stack Hub",
+			)
+		}
 		return &armcompute.DiagnosticsProfile{
 			BootDiagnostics: &armcompute.BootDiagnostics{
 				Enabled: ptr.To[bool](true),

--- a/pkg/cloud/azure/actuators/machine/reconciler_test.go
+++ b/pkg/cloud/azure/actuators/machine/reconciler_test.go
@@ -559,18 +559,25 @@ func TestCreateAvailabilitySet(t *testing.T) {
 func TestCreateDiagnosticsConfig(t *testing.T) {
 	testCases := []struct {
 		name           string
+		scope          *actuators.MachineScope
 		config         *machinev1.AzureMachineProviderSpec
 		expectedConfig *armcompute.DiagnosticsProfile
 		expectedError  error
 	}{
 		{
-			name:           "with no boot configuration",
+			name: "with no boot configuration",
+			scope: &actuators.MachineScope{
+				Machine: &machinev1.Machine{},
+			},
 			config:         &machinev1.AzureMachineProviderSpec{},
 			expectedConfig: nil,
 			expectedError:  nil,
 		},
 		{
 			name: "with no storage account type",
+			scope: &actuators.MachineScope{
+				Machine: &machinev1.Machine{},
+			},
 			config: &machinev1.AzureMachineProviderSpec{
 				Diagnostics: machinev1.AzureDiagnostics{
 					Boot: &machinev1.AzureBootDiagnostics{},
@@ -581,6 +588,9 @@ func TestCreateDiagnosticsConfig(t *testing.T) {
 		},
 		{
 			name: "with an invalid storage account type",
+			scope: &actuators.MachineScope{
+				Machine: &machinev1.Machine{},
+			},
 			config: &machinev1.AzureMachineProviderSpec{
 				Diagnostics: machinev1.AzureDiagnostics{
 					Boot: &machinev1.AzureBootDiagnostics{
@@ -592,7 +602,12 @@ func TestCreateDiagnosticsConfig(t *testing.T) {
 			expectedError:  machinecontroller.InvalidMachineConfiguration("unknown storage account type for boot diagnostics: \"foo\", supported types are AzureManaged & CustomerManaged"),
 		},
 		{
-			name: "with an Azure managed storage account",
+			name: "with an Azure managed storage account on public Azure",
+			scope: actuators.NewFakeMachineScope(actuators.FakeMachineScopeParams{
+				Machine:  &machinev1.Machine{},
+				CloudEnv: string(configv1.AzurePublicCloud),
+				Context:  context.Background(),
+			}),
 			config: &machinev1.AzureMachineProviderSpec{
 				Diagnostics: machinev1.AzureDiagnostics{
 					Boot: &machinev1.AzureBootDiagnostics{
@@ -609,6 +624,9 @@ func TestCreateDiagnosticsConfig(t *testing.T) {
 		},
 		{
 			name: "with an Customer managed storage account with no account URI",
+			scope: &actuators.MachineScope{
+				Machine: &machinev1.Machine{},
+			},
 			config: &machinev1.AzureMachineProviderSpec{
 				Diagnostics: machinev1.AzureDiagnostics{
 					Boot: &machinev1.AzureBootDiagnostics{
@@ -621,6 +639,9 @@ func TestCreateDiagnosticsConfig(t *testing.T) {
 		},
 		{
 			name: "with an Customer managed storage account with a valid account URI",
+			scope: &actuators.MachineScope{
+				Machine: &machinev1.Machine{},
+			},
 			config: &machinev1.AzureMachineProviderSpec{
 				Diagnostics: machinev1.AzureDiagnostics{
 					Boot: &machinev1.AzureBootDiagnostics{
@@ -639,13 +660,55 @@ func TestCreateDiagnosticsConfig(t *testing.T) {
 			},
 			expectedError: nil,
 		},
+		{
+			name: "with Azure managed storage account on Azure Stack Hub should fail",
+			scope: actuators.NewFakeMachineScope(actuators.FakeMachineScopeParams{
+				Machine:  &machinev1.Machine{},
+				CloudEnv: string(configv1.AzureStackCloud),
+				Context:  context.Background(),
+			}),
+			config: &machinev1.AzureMachineProviderSpec{
+				Diagnostics: machinev1.AzureDiagnostics{
+					Boot: &machinev1.AzureBootDiagnostics{
+						StorageAccountType: machinev1.AzureManagedAzureDiagnosticsStorage,
+					},
+				},
+			},
+			expectedConfig: nil,
+			expectedError:  machinecontroller.InvalidMachineConfiguration("AzureManaged boot diagnostics is not supported on Azure Stack Hub"),
+		},
+		{
+			name: "with Customer managed storage account on Azure Stack Hub should succeed",
+			scope: actuators.NewFakeMachineScope(actuators.FakeMachineScopeParams{
+				Machine:  &machinev1.Machine{},
+				CloudEnv: string(configv1.AzureStackCloud),
+				Context:  context.Background(),
+			}),
+			config: &machinev1.AzureMachineProviderSpec{
+				Diagnostics: machinev1.AzureDiagnostics{
+					Boot: &machinev1.AzureBootDiagnostics{
+						StorageAccountType: machinev1.CustomerManagedAzureDiagnosticsStorage,
+						CustomerManaged: &machinev1.AzureCustomerManagedBootDiagnostics{
+							StorageAccountURI: "https://mystackhubaccount.blob.local.azurestack.external/",
+						},
+					},
+				},
+			},
+			expectedConfig: &armcompute.DiagnosticsProfile{
+				BootDiagnostics: &armcompute.BootDiagnostics{
+					Enabled:    ptr.To[bool](true),
+					StorageURI: ptr.To[string]("https://mystackhubaccount.blob.local.azurestack.external/"),
+				},
+			},
+			expectedError: nil,
+		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			g := NewWithT(t)
 
-			config, err := createDiagnosticsConfig(tc.config)
+			config, err := createDiagnosticsConfig(tc.scope, tc.config)
 			if tc.expectedError != nil {
 				g.Expect(err).To(MatchError(tc.expectedError))
 			} else {


### PR DESCRIPTION
Azure Stack Hub does not support `AzureManaged` boot diagnostics storage and requires `UserManaged` storage accounts. Without validation, users experience cryptic 400 errors from the Azure API when attempting to use `AzureManaged` boot diagnostics on Stack Hub.

This change adds validation in the `createDiagnosticsConfig` function to detect when `AzureManaged` boot diagnostics is configured on Azure Stack Hub and returns a clear InvalidMachineConfiguration error.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced, environment-aware validation for boot diagnostics on Azure Stack Hub to block unsupported configurations.
  * Managed diagnostics storage settings are now checked earlier to prevent invalid deployments.
  * Error messages and failure handling improved to give clearer feedback when diagnostics configurations are not supported.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->