### PR TITLE
OCPSTRAT-1672: Update to use the user specified armEndpoint

### DIFF
--- a/pkg/cloud/azure/actuators/machine_scope.go
+++ b/pkg/cloud/azure/actuators/machine_scope.go
@@ -474,7 +474,7 @@ func getValueFromSecretOrEnvironment(secretData map[string][]byte, dataKey strin
 }
 
 func getEnvironment(m *MachineScope) (*azure.Environment, error) {
-	if m.IsStackHub() {
+	if m.IsStackHub() || m.armEndpoint != "" {
 		env, err := azure.EnvironmentFromURL(m.armEndpoint)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
In the new Azure IL-6 regions the armEndpoint is used to lookup all other Azure API endpoints. Update the machine api provider such that when a user specifies an armEndpoint during installation, the operator will use it to find the Azure API URIs.