### PR TITLE
CORS-4501: azure: Detach frontend count from backend

### DIFF
--- a/pkg/cloud/azure/services/networkinterfaces/networkinterfaces.go
+++ b/pkg/cloud/azure/services/networkinterfaces/networkinterfaces.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2021-02-01/network"
 	"github.com/Azure/go-autorest/autorest/to"
@@ -192,25 +193,24 @@ func (s *Service) CreateOrUpdate(ctx context.Context, spec azure.Spec) error {
 
 		loadBalancerInboundNatRules := []network.InboundNatRule{}
 		loadBalancerInboundNatRulesV6 := []network.InboundNatRule{}
-		// loadbalancers can have multiple frontends and backends with different IP families
-		for i, ipConfig := range *lb.FrontendIPConfigurations {
-			// iterate only for the frontends that have backends configured
-			if i >= len(*lb.BackendAddressPools) {
-				break
+		// Classify backend pools by name: pools with "-v6" suffix are IPv6.
+		if lb.BackendAddressPools != nil {
+			for _, pool := range *lb.BackendAddressPools {
+				if pool.Name == nil || pool.ID == nil {
+					continue
+				}
+				if strings.HasSuffix(*pool.Name, "-v6") {
+					backendAddressPoolsV6 = append(backendAddressPoolsV6,
+						network.BackendAddressPool{ID: pool.ID})
+				} else {
+					backendAddressPools = append(backendAddressPools,
+						network.BackendAddressPool{ID: pool.ID})
+				}
 			}
-			if ipConfig.PrivateIPAddressVersion == network.IPVersionIPv6 {
-				backendAddressPoolsV6 = append(backendAddressPoolsV6,
-					network.BackendAddressPool{
-						ID: (*lb.BackendAddressPools)[i].ID,
-					})
-			} else {
-				backendAddressPools = append(backendAddressPools,
-					network.BackendAddressPool{
-						ID: (*lb.BackendAddressPools)[i].ID,
-					})
-			}
+		}
 
-			if nicSpec.NatRule != nil {
+		if nicSpec.NatRule != nil {
+			for _, ipConfig := range *lb.FrontendIPConfigurations {
 				if ipConfig.PrivateIPAddressVersion == network.IPVersionIPv6 {
 					loadBalancerInboundNatRulesV6 = append(loadBalancerInboundNatRulesV6,
 						network.InboundNatRule{ID: (*lb.InboundNatRules)[*nicSpec.NatRule].ID})
@@ -237,22 +237,19 @@ func (s *Service) CreateOrUpdate(ctx context.Context, spec azure.Spec) error {
 		if !ok {
 			return errors.New("internal load balancer get returned invalid network interface")
 		}
-		// loadbalancers can have multiple frontends and backends with different IP families
-		for i, ipConfig := range *internallb.FrontendIPConfigurations {
-			// iterate only for the frontends that have backends configured
-			if i >= len(*internallb.BackendAddressPools) {
-				break
-			}
-			if ipConfig.PrivateIPAddressVersion == network.IPVersionIPv6 {
-				backendAddressPoolsV6 = append(backendAddressPoolsV6,
-					network.BackendAddressPool{
-						ID: (*internallb.BackendAddressPools)[i].ID,
-					})
-			} else {
-				backendAddressPools = append(backendAddressPools,
-					network.BackendAddressPool{
-						ID: (*internallb.BackendAddressPools)[i].ID,
-					})
+		// Classify internal LB backend pools by name suffix
+		if internallb.BackendAddressPools != nil {
+			for _, pool := range *internallb.BackendAddressPools {
+				if pool.Name == nil || pool.ID == nil {
+					continue
+				}
+				if strings.HasSuffix(*pool.Name, "-v6") {
+					backendAddressPoolsV6 = append(backendAddressPoolsV6,
+						network.BackendAddressPool{ID: pool.ID})
+				} else {
+					backendAddressPools = append(backendAddressPools,
+						network.BackendAddressPool{ID: pool.ID})
+				}
 			}
 		}
 	}

--- a/pkg/cloud/azure/services/networkinterfaces/networkinterfaces_stack.go
+++ b/pkg/cloud/azure/services/networkinterfaces/networkinterfaces_stack.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/profiles/2019-03-01/network/mgmt/network"
 	"github.com/Azure/go-autorest/autorest/to"
@@ -147,20 +148,24 @@ func (s *StackHubService) CreateOrUpdate(ctx context.Context, spec azure.Spec) e
 
 		loadBalancerInboundNatRules := []network.InboundNatRule{}
 		loadBalancerInboundNatRulesV6 := []network.InboundNatRule{}
-		// loadbalancers can have multiple frontends and backends with different IP families
-		// TODO: this logic is different in public azure, check that no functionality is broken by this
-		for i, _ := range *lb.FrontendIPConfigurations {
-			// iterate only for the frontends that have backends configured
-			if i >= len(*lb.BackendAddressPools) {
-				break
+		// Classify backend pools by name: pools with "-v6" suffix are IPv6.
+		if lb.BackendAddressPools != nil {
+			for _, pool := range *lb.BackendAddressPools {
+				if pool.Name == nil || pool.ID == nil {
+					continue
+				}
+				if strings.HasSuffix(*pool.Name, "-v6") {
+					backendAddressPoolsV6 = append(backendAddressPoolsV6,
+						network.BackendAddressPool{ID: pool.ID})
+				} else {
+					backendAddressPools = append(backendAddressPools,
+						network.BackendAddressPool{ID: pool.ID})
+				}
 			}
+		}
 
-			backendAddressPools = append(backendAddressPools,
-				network.BackendAddressPool{
-					ID: (*lb.BackendAddressPools)[i].ID,
-				})
-
-			if nicSpec.NatRule != nil {
+		if nicSpec.NatRule != nil {
+			for range *lb.FrontendIPConfigurations {
 				loadBalancerInboundNatRules = append(loadBalancerInboundNatRules,
 					network.InboundNatRule{ID: (*lb.InboundNatRules)[*nicSpec.NatRule].ID})
 			}
@@ -182,18 +187,20 @@ func (s *StackHubService) CreateOrUpdate(ctx context.Context, spec azure.Spec) e
 		if !ok {
 			return errors.New("internal load balancer get returned invalid network interface")
 		}
-		// loadbalancers can have multiple frontends and backends with different IP families
-		// TODO: this logic is different in public azure, check that no functionality is broken by this
-		for i, _ := range *internallb.FrontendIPConfigurations {
-			// iterate only for the frontends that have backends configured
-			if i >= len(*internallb.BackendAddressPools) {
-				break
+		// Classify internal LB backend pools by name suffix
+		if internallb.BackendAddressPools != nil {
+			for _, pool := range *internallb.BackendAddressPools {
+				if pool.Name == nil || pool.ID == nil {
+					continue
+				}
+				if strings.HasSuffix(*pool.Name, "-v6") {
+					backendAddressPoolsV6 = append(backendAddressPoolsV6,
+						network.BackendAddressPool{ID: pool.ID})
+				} else {
+					backendAddressPools = append(backendAddressPools,
+						network.BackendAddressPool{ID: pool.ID})
+				}
 			}
-
-			backendAddressPools = append(backendAddressPools,
-				network.BackendAddressPool{
-					ID: (*internallb.BackendAddressPools)[i].ID,
-				})
 		}
 	}
 	nicConfig.LoadBalancerBackendAddressPools = &backendAddressPools


### PR DESCRIPTION
Currently, the assumption is that there will be equal number of frontend IP configs and backend pools but with the latest dualstack work, this will change. Detaching the logic that ties the counts together and making it simpler.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved backend pool classification for IPv6 and standard load balancer configurations
  * Enhanced nil-safety checks for backend address pools in network interface setup
  * Optimized NAT rule processing to execute only when explicitly configured

<!-- end of auto-generated comment: release notes by coderabbit.ai -->