### PR TITLE
PIXAA-7: Leverage SpotRebalanceRecommendation for instance termination when available

### DIFF
--- a/pkg/termination/termination.go
+++ b/pkg/termination/termination.go
@@ -22,9 +22,16 @@ import (
 const (
 	// azureTerminationEndpointURL see the following link for more details about the endpoint
 	// https://docs.microsoft.com/en-us/azure/virtual-machines/windows/scheduled-events#endpoint-discovery
-	azureTerminationEndpointURL                          = "http://169.254.169.254/metadata/scheduledevents?api-version=2019-08-01"
-	terminatingConditionType    corev1.NodeConditionType = "Terminating"
-	terminationRequestedReason                           = "TerminationRequested"
+	azureTerminationEndpointURL = "http://169.254.169.254/metadata/scheduledevents"
+
+	// apiVersion20240709 adds SpotRebalanceRecommendation as an event type, but as of June 2026 is not generally available.
+	apiVersion20240709 = "?api-version=2024-07-09"
+
+	// apiVersion20200701 is the most recent generally available API version for scheduled events.
+	apiVersion20200701 = "?api-version=2020-07-01"
+
+	terminatingConditionType   corev1.NodeConditionType = "Terminating"
+	terminationRequestedReason string                   = "TerminationRequested"
 )
 
 // Handler represents a handler that will run to check the termination
@@ -40,7 +47,7 @@ func NewHandler(logger logr.Logger, cfg *rest.Config, pollInterval time.Duration
 		return nil, fmt.Errorf("error creating client: %v", err)
 	}
 
-	pollURL, err := url.Parse(azureTerminationEndpointURL)
+	pollURL, err := getPollURL(context.Background(), logger)
 	if err != nil {
 		// This should never happen
 		panic(err)
@@ -56,6 +63,61 @@ func NewHandler(logger logr.Logger, cfg *rest.Config, pollInterval time.Duration
 		namespace:    namespace,
 		log:          logger,
 	}, nil
+}
+
+// getPollURL gets the poll URL for the termination endpoint.
+// It first tries to use the 2024-07-09 API version, and if that is not available, it falls back to the 2020-07-01 API version.
+func getPollURL(ctx context.Context, logger logr.Logger) (*url.URL, error) {
+	pollURL, err := url.Parse(azureTerminationEndpointURL + apiVersion20240709)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing poll URL: %v", err)
+	}
+
+	available, err := endpointAvailable(ctx, pollURL)
+	if err != nil {
+		return nil, fmt.Errorf("error checking endpoint availability: %v", err)
+	}
+	if available {
+		logger.V(1).Info("Using API version 2024-07-09")
+		return pollURL, nil
+	}
+
+	pollURL, err = url.Parse(azureTerminationEndpointURL + apiVersion20200701)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing poll URL: %v", err)
+	}
+
+	logger.V(1).Info("Using API version 2020-07-01, SpotRebalanceRecommendation is not available")
+	return pollURL, nil
+}
+
+// endpointAvailable checks if the endpoint is available by making a GET request to the endpoint.
+// When an API version is not available, the endpoint will return a 404.
+func endpointAvailable(ctx context.Context, pollURL *url.URL) (bool, error) {
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, "GET", pollURL.String(), nil)
+	if err != nil {
+		return false, fmt.Errorf("error creating request: %v", err)
+	}
+
+	req.Header.Add("Metadata", "true")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return false, fmt.Errorf("error sending request: %v", err)
+	}
+	defer resp.Body.Close()
+
+	switch resp.StatusCode {
+	case http.StatusOK:
+		return true, nil
+	case http.StatusNotFound:
+		return false, nil
+	default:
+		return false, fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+	}
 }
 
 // handler implements the logic to check the termination endpoint and delete the
@@ -126,7 +188,7 @@ func (h *handler) run(ctx context.Context) error {
 		}
 
 		for _, event := range s.Events {
-			if event.EventType == preemptEventType {
+			if event.EventType == preemptEventType || event.EventType == spotRebalanceRecommendationEventType {
 				// Instance marked for termination
 				return true, nil
 			}
@@ -215,6 +277,7 @@ func addNodeTerminationCondition(node *corev1.Node) {
 }
 
 const preemptEventType = "Preempt"
+const spotRebalanceRecommendationEventType = "SpotRebalanceRecommendation"
 
 // scheduledEvents represents metadata response, more detailed info can be found here:
 // https://docs.microsoft.com/en-us/azure/virtual-machines/linux/scheduled-events#use-the-api

--- a/pkg/termination/termination_test.go
+++ b/pkg/termination/termination_test.go
@@ -77,15 +77,14 @@ var _ = Describe("Handler Suite", func() {
 		testNode = newTestNode(nodeName)
 		createNode(testNode)
 
-		// use NewHandler() instead of manual construction in order to test NewHandler() logic
-		// like checking that machine api is added to scheme
-		handlerInterface, err := NewHandler(klogr.New(), cfg, 100*time.Millisecond, "", nodeName)
-		Expect(err).ToNot(HaveOccurred())
-
-		h = handlerInterface.(*handler)
-
-		// set pollURL so we can override initial value later
-		h.pollURL = nil
+		h = &handler{
+			client:       k8sClient,
+			pollURL:      nil,
+			pollInterval: 100 * time.Millisecond,
+			nodeName:     nodeName,
+			namespace:    testNamespace,
+			log:          klogr.New(),
+		}
 	})
 
 	JustBeforeEach(func() {
@@ -123,66 +122,133 @@ var _ = Describe("Handler Suite", func() {
 	Context("when polling the termination endpoint", func() {
 		var counter int32
 
-		BeforeEach(func() {
-			counter = 0
-
-			// Ensure the polling logic is excercised in tests
-			httpHandler = newMockHTTPHandler(func(rw http.ResponseWriter, req *http.Request) {
-				if atomic.LoadInt32(&counter) == 4 {
-					rw.Write([]byte(`{"DocumentIncarnation":0,"Events":[{"EventType":"Preempt", "ResourceType": "VirtualMachine"}]}`))
-				} else {
-					atomic.AddInt32(&counter, 1)
-					rw.Write([]byte(`{"DocumentIncarnation":0,"Events":[]}`))
-				}
-			})
-		})
-
-		Context("and the handler is stopped", func() {
-			JustBeforeEach(func() {
-				// Ensure the polling logic is tested as well
-				for atomic.LoadInt32(&counter) < 4 {
-					// use 50ms since polling is set to 100ms
-					time.Sleep(50 * time.Millisecond)
-					continue
-				}
-
-				close(stop)
-			})
-
-			It("should not return an error", func() {
-				Eventually(errs).Should(Receive(BeNil()))
-			})
-
-			It("should not mark the node for deletion", func() {
-				Consistently(nodeMarkedForDeletion(testNode.Name)).Should(BeFalse())
-			})
-		})
-
-		Context("and the instance termination notice is fulfilled", func() {
-			JustBeforeEach(func() {
-				// Ensure the polling logic is tested as well
-				for atomic.LoadInt32(&counter) < 4 {
-					// use 50ms since polling is set to 100ms
-					time.Sleep(50 * time.Millisecond)
-					continue
-				}
-			})
-
-			It("should mark the node for deletion", func() {
-				Eventually(nodeMarkedForDeletion(testNode.Name)).Should(BeTrue())
-			})
-		})
-
-		Context("and the instance termination notice is not fulfilled", func() {
+		Context("with Preempt event type", func() {
 			BeforeEach(func() {
+				counter = 0
+
+				// Ensure the polling logic is excercised in tests
 				httpHandler = newMockHTTPHandler(func(rw http.ResponseWriter, req *http.Request) {
-					atomic.AddInt32(&counter, 1)
-					emptyEvents(rw, req)
+					if atomic.LoadInt32(&counter) == 4 {
+						rw.Write([]byte(`{"DocumentIncarnation":0,"Events":[{"EventType":"Preempt", "ResourceType": "VirtualMachine"}]}`))
+					} else {
+						atomic.AddInt32(&counter, 1)
+						rw.Write([]byte(`{"DocumentIncarnation":0,"Events":[]}`))
+					}
 				})
 			})
 
-			It("should not mark the node for deletion", func() {
-				Consistently(nodeMarkedForDeletion(testNode.Name)).Should(BeFalse())
+			Context("and the handler is stopped", func() {
+				JustBeforeEach(func() {
+					// Ensure the polling logic is tested as well
+					for atomic.LoadInt32(&counter) < 4 {
+						// use 50ms since polling is set to 100ms
+						time.Sleep(50 * time.Millisecond)
+						continue
+					}
+
+					close(stop)
+				})
+
+				It("should not return an error", func() {
+					Eventually(errs).Should(Receive(BeNil()))
+				})
+
+				It("should not mark the node for deletion", func() {
+					Consistently(nodeMarkedForDeletion(testNode.Name)).Should(BeFalse())
+				})
+			})
+
+			Context("and the instance termination notice is fulfilled", func() {
+				JustBeforeEach(func() {
+					// Ensure the polling logic is tested as well
+					for atomic.LoadInt32(&counter) < 4 {
+						// use 50ms since polling is set to 100ms
+						time.Sleep(50 * time.Millisecond)
+						continue
+					}
+				})
+
+				It("should mark the node for deletion", func() {
+					Eventually(nodeMarkedForDeletion(testNode.Name)).Should(BeTrue())
+				})
+			})
+
+			Context("and the instance termination notice is not fulfilled", func() {
+				BeforeEach(func() {
+					httpHandler = newMockHTTPHandler(func(rw http.ResponseWriter, req *http.Request) {
+						atomic.AddInt32(&counter, 1)
+						emptyEvents(rw, req)
+					})
+				})
+
+				It("should not mark the node for deletion", func() {
+					Consistently(nodeMarkedForDeletion(testNode.Name)).Should(BeFalse())
+				})
+			})
+		})
+
+		Context("with SpotRebalanceRecommendation event type", func() {
+			BeforeEach(func() {
+				counter = 0
+
+				// Ensure the polling logic is excercised in tests
+				httpHandler = newMockHTTPHandler(func(rw http.ResponseWriter, req *http.Request) {
+					if atomic.LoadInt32(&counter) == 4 {
+						rw.Write([]byte(`{"DocumentIncarnation":0,"Events":[{"EventType":"SpotRebalanceRecommendation", "ResourceType": "VirtualMachine"}]}`))
+					} else {
+						atomic.AddInt32(&counter, 1)
+						rw.Write([]byte(`{"DocumentIncarnation":0,"Events":[]}`))
+					}
+				})
+			})
+
+			Context("and the handler is stopped", func() {
+				JustBeforeEach(func() {
+					// Ensure the polling logic is tested as well
+					for atomic.LoadInt32(&counter) < 4 {
+						// use 50ms since polling is set to 100ms
+						time.Sleep(50 * time.Millisecond)
+						continue
+					}
+
+					close(stop)
+				})
+
+				It("should not return an error", func() {
+					Eventually(errs).Should(Receive(BeNil()))
+				})
+
+				It("should not mark the node for deletion", func() {
+					Consistently(nodeMarkedForDeletion(testNode.Name)).Should(BeFalse())
+				})
+			})
+
+			Context("and the instance termination notice is fulfilled", func() {
+				JustBeforeEach(func() {
+					// Ensure the polling logic is tested as well
+					for atomic.LoadInt32(&counter) < 4 {
+						// use 50ms since polling is set to 100ms
+						time.Sleep(50 * time.Millisecond)
+						continue
+					}
+				})
+
+				It("should mark the node for deletion", func() {
+					Eventually(nodeMarkedForDeletion(testNode.Name)).Should(BeTrue())
+				})
+			})
+
+			Context("and the instance termination notice is not fulfilled", func() {
+				BeforeEach(func() {
+					httpHandler = newMockHTTPHandler(func(rw http.ResponseWriter, req *http.Request) {
+						atomic.AddInt32(&counter, 1)
+						emptyEvents(rw, req)
+					})
+				})
+
+				It("should not mark the node for deletion", func() {
+					Consistently(nodeMarkedForDeletion(testNode.Name)).Should(BeFalse())
+				})
 			})
 		})
 	})


### PR DESCRIPTION
This updates the Azure spot termination handler implementation to understand a tech preview MS feature that is a SpotRebalanceRecommendation.

This new event type means you can get up to 15 minutes warning for nodes going away vs the 30 seconds you get with the preempt event. This should improve the likelihood of successful draining in the event of a spot instance going away

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Treats spot rebalance recommendation events as valid termination signals alongside preempt events.

* **Improvements**
  * Detects and probes Azure scheduled-events API versions, automatically falling back between endpoints for more reliable polling.

* **Tests**
  * Reorganized and extended polling tests to cover both event types, verify stop/edge-case behavior, and ensure correct node-marking when notices occur.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->